### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7.7, 3.8]
+                python-version: [3.6, 3.7.7, 3.8]
 
         services:
             rabbitmq:

--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -61,7 +61,7 @@ def cmd_install_family(archive, label, description, archive_format, family_type,
             family = create_family_from_archive(family_type, label, handle.name, fmt=archive_format)
 
     family.description = description
-    echo.echo_success('installed `{}` containing {} pseudo potentials'.format(label, family.count()))
+    echo.echo_success(f'installed `{label}` containing {family.count()} pseudo potentials')
 
 
 @cmd_install.command('sssp')
@@ -88,17 +88,17 @@ def cmd_install_sssp(version, functional, protocol, traceback):
 
     configuration = SsspConfiguration(version, functional, protocol)
     label = SsspFamily.format_configuration_label(configuration)
-    description = 'SSSP v{} {} {} installed with aiida-pseudo v{}'.format(*configuration, __version__)
+    description = f'SSSP v{version} {functional} {protocol} installed with aiida-pseudo v{__version__}'
 
     if configuration not in SsspFamily.valid_configurations:
-        echo.echo_critical('{} {} {} is not a valid SSSP configuration'.format(*configuration))
+        echo.echo_critical(f'{version} {functional} {protocol} is not a valid SSSP configuration')
 
     if QueryBuilder().append(SsspFamily, filters={'label': label}).first():
-        echo.echo_critical('{}<{}> is already installed'.format(SsspFamily.__name__, label))
+        echo.echo_critical(f'{SsspFamily.__name__}<{label}> is already installed')
 
     with tempfile.TemporaryDirectory() as dirpath:
 
-        url_archive = '{}/SSSP_{}_{}_{}.tar.gz'.format(URL_SSSP_BASE, version, functional, protocol)
+        url_archive = f'{URL_SSSP_BASE}/SSSP_{version}_{functional}_{protocol}.tar.gz'
         filepath_archive = os.path.join(dirpath, 'archive.tar.gz')
 
         with attempt('downloading selected pseudo potentials archive... ', include_traceback=traceback):
@@ -107,10 +107,10 @@ def cmd_install_sssp(version, functional, protocol, traceback):
             with open(filepath_archive, 'wb') as handle:
                 handle.write(response.content)
                 handle.flush()
-                description += '\nArchive pseudos md5: {}'.format(md5_file(filepath_archive))
+                description += f'\nArchive pseudos md5: {md5_file(filepath_archive)}'
 
         with attempt('unpacking archive and parsing pseudos... ', include_traceback=traceback):
             family = create_family_from_archive(SsspFamily, label, filepath_archive)
 
         family.description = description
-        echo.echo_success('installed `{}` containing {} pseudo potentials'.format(label, family.count()))
+        echo.echo_success(f'installed `{label}` containing {family.count()} pseudo potentials')

--- a/aiida_pseudo/cli/params/types.py
+++ b/aiida_pseudo/cli/params/types.py
@@ -32,11 +32,11 @@ class PseudoPotentialFamilyTypeParam(click.ParamType):
 
         try:
             family_type = GroupFactory(value)
-        except exceptions.EntryPointError:
-            raise click.BadParameter('`{}` is not an existing group plugin.'.format(value))
+        except exceptions.EntryPointError as exception:
+            raise click.BadParameter(f'`{value}` is not an existing group plugin.') from exception
 
         if not issubclass(family_type, PseudoPotentialFamily):
-            raise click.BadParameter('`{}` entry point is not a subclass of `PseudoPotentialFamily`.'.format(value))
+            raise click.BadParameter(f'`{value}` entry point is not a subclass of `PseudoPotentialFamily`.')
 
         PseudoPotentialFamily.entry_point = value
 

--- a/aiida_pseudo/cli/utils.py
+++ b/aiida_pseudo/cli/utils.py
@@ -52,11 +52,11 @@ def create_family_from_archive(cls, label, filepath_archive, fmt=None):
         try:
             shutil.unpack_archive(filepath_archive, dirpath, format=fmt)
         except shutil.ReadError as exception:
-            raise OSError('failed to unpack the archive `{}`: {}'.format(filepath_archive, exception))
+            raise OSError(f'failed to unpack the archive `{filepath_archive}`: {exception}') from exception
 
         try:
             family = cls.create_from_folder(dirpath, label)
         except ValueError as exception:
-            raise OSError('failed to parse pseudos from `{}`: {}'.format(dirpath, exception))
+            raise OSError(f'failed to parse pseudos from `{dirpath}`: {exception}') from exception
 
     return family

--- a/aiida_pseudo/data/pseudo/pseudo.py
+++ b/aiida_pseudo/data/pseudo/pseudo.py
@@ -26,7 +26,7 @@ class PseudoPotentialData(SingleFileData):
         :raises ValueError: if the element symbol is invalid.
         """
         if element not in [values['symbol'] for values in elements.values()]:
-            raise ValueError('`{}` is not a valid element.'.format(element))
+            raise ValueError(f'`{element}` is not a valid element.')
 
     def validate_md5(self, md5: str):
         """Validate that the md5 checksum matches that of the currently stored file.
@@ -37,7 +37,7 @@ class PseudoPotentialData(SingleFileData):
         with self.open(mode='rb') as handle:
             md5_file = md5_from_filelike(handle)
             if md5 != md5_file:
-                raise ValueError('md5 does not match that of stored file: {} != {}'.format(md5, md5_file))
+                raise ValueError(f'md5 does not match that of stored file: {md5} != {md5_file}')
 
     def set_file(self, stream: typing.BinaryIO, filename: str = None, **kwargs):
         """Set the file content.
@@ -56,13 +56,13 @@ class PseudoPotentialData(SingleFileData):
         """
         try:
             self.validate_element(self.element)
-        except ValueError:
-            raise StoringNotAllowed('no valid element has been defined.')
+        except ValueError as exception:
+            raise StoringNotAllowed('no valid element has been defined.') from exception
 
         try:
             self.validate_md5(self.md5)
         except ValueError as exception:
-            raise StoringNotAllowed(exception)
+            raise StoringNotAllowed(exception) from exception
 
         return super().store()
 

--- a/aiida_pseudo/groups/family/sssp.py
+++ b/aiida_pseudo/groups/family/sssp.py
@@ -47,6 +47,6 @@ class SsspFamily(UpfFamily):
     def __init__(self, label=None, **kwargs):
         """Construct a new instance, validating that the label matches the required format."""
         if label not in self.get_valid_labels():
-            raise ValueError('the label `{}` is not a valid SSSP configuration label.'.format(label))
+            raise ValueError(f'the label `{label}` is not a valid SSSP configuration label.')
 
         super().__init__(label=label, **kwargs)

--- a/setup.json
+++ b/setup.json
@@ -8,7 +8,6 @@
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8"
@@ -28,7 +27,7 @@
             "pseudo.family.sssp = aiida_pseudo.groups.family.sssp:SsspFamily"
         ]
     },
-    "python_requires": ">=3.5",
+    "python_requires": ">=3.6",
     "install_requires": [
         "aiida-core~=1.3",
         "click~=7.0",

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -17,7 +17,7 @@ def test_install_family(run_cli_command, get_pseudo_archive):
     options = ['-D', description, filepath_archive, label]
 
     result = run_cli_command(cmd_install_family, options)
-    assert 'installed `{}`'.format(label) in result.output
+    assert f'installed `{label}`' in result.output
     assert PseudoPotentialFamily.objects.count() == 1
 
     family = PseudoPotentialFamily.objects.get(label=label)
@@ -39,7 +39,7 @@ def test_install_family_url(run_cli_command):
     options = ['-D', description, filepath_archive, label, '-T', 'pseudo.family.upf']
 
     result = run_cli_command(cmd_install_family, options)
-    assert 'installed `{}`'.format(label) in result.output
+    assert f'installed `{label}`' in result.output
     assert UpfFamily.objects.count() == 1
 
     family = UpfFamily.objects.get(label=label)
@@ -57,7 +57,7 @@ def test_install_family_upf(run_cli_command, get_pseudo_archive):
     options = ['-D', description, '-T', 'pseudo.family.upf', filepath_archive, label]
 
     result = run_cli_command(cmd_install_family, options)
-    assert 'installed `{}`'.format(label) in result.output
+    assert f'installed `{label}`' in result.output
     assert UpfFamily.objects.count() == 1
 
     family = UpfFamily.objects.get(label=label)
@@ -77,7 +77,7 @@ def test_install_sssp(run_cli_command):
     assert QueryBuilder().append(SsspFamily).count() == 1
 
     family = QueryBuilder().append(SsspFamily).one()[0]
-    assert 'SSSP v1.1 PBE efficiency installed with aiida-pseudo v{}'.format(__version__) in family.description
+    assert f'SSSP v1.1 PBE efficiency installed with aiida-pseudo v{__version__}' in family.description
     assert 'Archive pseudos md5: 4803ce9fd1d84c777f87173cd4a2de33' in family.description
 
     result = run_cli_command(cmd_install_sssp, raises=SystemExit)

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -51,7 +51,7 @@ def test_attempt_sucess(capsys):
         pass
 
     captured = capsys.readouterr()
-    assert captured.out == 'Info: {} [OK]\n'.format(message)
+    assert captured.out == f'Info: {message} [OK]\n'
     assert captured.err == ''
 
 
@@ -65,8 +65,8 @@ def test_attempt_exception(capsys):
             raise RuntimeError(exception)
 
     captured = capsys.readouterr()
-    assert captured.out == 'Info: {} [FAILED]\n'.format(message)
-    assert captured.err == 'Critical: {}\n'.format(exception)
+    assert captured.out == f'Info: {message} [FAILED]\n'
+    assert captured.err == f'Critical: {exception}\n'
 
 
 def test_attempt_exception_traceback(capsys):
@@ -79,6 +79,6 @@ def test_attempt_exception_traceback(capsys):
             raise RuntimeError(exception)
 
     captured = capsys.readouterr()
-    assert captured.out == 'Info: {} [FAILED]\n'.format(message)
-    assert captured.err.startswith('Critical: {}\n'.format(exception))
+    assert captured.out == f'Info: {message} [FAILED]\n'
+    assert captured.err.startswith(f'Critical: {exception}\n')
     assert 'Traceback' in captured.err

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,11 +101,11 @@ def get_pseudo_potential_data(filepath_pseudos):
         """
         if entry_point is None:
             cls = DataFactory('pseudo')
-            pseudo = cls(io.BytesIO(b'content'), '{}.pseudo'.format(element))
+            pseudo = cls(io.BytesIO(b'content'), f'{element}.pseudo')
             pseudo.element = element
         else:
-            cls = DataFactory('pseudo.{}'.format(entry_point))
-            filename = '{}.{}'.format(element, entry_point)
+            cls = DataFactory(f'pseudo.{entry_point}')
+            filename = f'{element}.{entry_point}'
             with open(os.path.join(filepath_pseudos(entry_point), filename), 'rb') as handle:
                 pseudo = cls(handle, filename)
 


### PR DESCRIPTION
This allows to also start using f-strings. All old-style formatted
strings are replaced with the new f-strings introduced in Python 3.6.