### PR TITLE
`PseudoPotentialFamily.get_pseudos`: turn arguments into keyword only

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,7 +1,8 @@
 [style]
-based_on_style = google
-column_limit = 120
 align_closing_bracket_with_visual_indent = true
+based_on_style = google
 coalesce_brackets = true
+column_limit = 120
 dedent_closing_brackets = true
 indent_dictionary_value = false
+split_arguments_when_comma_terminated = true

--- a/aiida_pseudo/groups/family/pseudo.py
+++ b/aiida_pseudo/groups/family/pseudo.py
@@ -228,7 +228,12 @@ class PseudoPotentialFamily(Group):
 
         return pseudo
 
-    def get_pseudos(self, elements: Union[List[str], Tuple[str], StructureData]) -> Mapping[str, StructureData]:
+    def get_pseudos(
+        self,
+        *,
+        elements: Union[List[str], Tuple[str]] = None,
+        structure: StructureData = None,
+    ) -> Mapping[str, StructureData]:
         """Return the mapping of kind names on pseudo potential data nodes for the given list of elements or structure.
 
         :param elements: list of element symbols.
@@ -236,10 +241,19 @@ class PseudoPotentialFamily(Group):
         :return: dictionary mapping the kind names of a structure on the corresponding pseudo potential data nodes.
         :raises ValueError: if the family does not contain a pseudo for any of the elements of the given structure.
         """
-        if not isinstance(elements, (list, tuple)) and not isinstance(elements, StructureData):
-            raise ValueError('elements should either be a list of symbols or a StructureData instance.')
+        if elements is not None and structure is not None:
+            raise ValueError('cannot specify both keyword arguments `elements` and `structure`.')
 
-        if isinstance(elements, StructureData):
-            elements = [kind.symbol for kind in elements.kinds]
+        if elements is None and structure is None:
+            raise ValueError('have to specify one of the keyword arguments `elements` and `structure`.')
+
+        if elements is not None and not isinstance(elements, (list, tuple)) and not isinstance(elements, StructureData):
+            raise ValueError('elements should be a list or tuple of symbols.')
+
+        if structure is not None and not isinstance(structure, StructureData):
+            raise ValueError('structure should be a `StructureData` instance.')
+
+        if structure is not None:
+            elements = [kind.symbol for kind in structure.kinds]
 
         return {element: self.get_pseudo(element) for element in elements}

--- a/tests/groups/family/test_pseudo.py
+++ b/tests/groups/family/test_pseudo.py
@@ -312,19 +312,29 @@ def test_get_pseudo(get_pseudo_family):
 
 
 @pytest.mark.usefixtures('clear_db')
-def test_get_pseudos_raise(get_pseudo_family):
+def test_get_pseudos_raise(get_pseudo_family, generate_structure):
     """Test the `PseudoPotentialFamily.get_pseudos` method when it is supposed to raise."""
     elements = ('Ar', 'He', 'Ne')
+    structure = generate_structure(elements)
     family = get_pseudo_family(elements=elements[:2])  # Create family with only subset of the elements
 
-    with pytest.raises(TypeError, match='missing 1 required positional argument:.*'):
+    with pytest.raises(ValueError, match='have to specify one of the keyword arguments `elements` and `structure`.'):
         family.get_pseudos()
 
-    with pytest.raises(ValueError, match='elements should either be a list of symbols or a StructureData instance.'):
+    with pytest.raises(ValueError, match='cannot specify both keyword arguments `elements` and `structure`.'):
+        family.get_pseudos(elements=elements, structure=structure)
+
+    with pytest.raises(ValueError, match='elements should be a list or tuple of symbols.'):
         family.get_pseudos(elements={'He', 'Ar'})
+
+    with pytest.raises(ValueError, match='structure should be a `StructureData` instance.'):
+        family.get_pseudos(structure={'He', 'Ar'})
 
     with pytest.raises(ValueError, match=r'family `.*` does not contain pseudo for element `.*`'):
         family.get_pseudos(elements=elements)
+
+    with pytest.raises(ValueError, match=r'family `.*` does not contain pseudo for element `.*`'):
+        family.get_pseudos(structure=structure)
 
 
 @pytest.mark.usefixtures('clear_db')
@@ -333,7 +343,7 @@ def test_get_pseudos_list(get_pseudo_family):
     elements = ('Ar', 'He', 'Ne')
     family = get_pseudo_family(elements=elements)
 
-    pseudos = family.get_pseudos(elements)
+    pseudos = family.get_pseudos(elements=elements)
     assert isinstance(pseudos, dict)
     for element in elements:
         assert isinstance(pseudos[element], PseudoPotentialData)
@@ -346,7 +356,7 @@ def test_get_pseudos_structure(get_pseudo_family, generate_structure):
     structure = generate_structure(elements)
     family = get_pseudo_family(elements=elements)
 
-    pseudos = family.get_pseudos(structure)
+    pseudos = family.get_pseudos(structure=structure)
     assert isinstance(pseudos, dict)
     for element in elements:
         assert isinstance(pseudos[element], PseudoPotentialData)


### PR DESCRIPTION
Fixes #6 

Also create a separate keyword for `structure` instead of overloading
`elements`, which is clearer from a user's perspective.