### PR TITLE
`PseudoPotentialData`: maintain correct signature for `store` method

### DIFF
--- a/aiida_pseudo/data/pseudo/pseudo.py
+++ b/aiida_pseudo/data/pseudo/pseudo.py
@@ -49,7 +49,7 @@ class PseudoPotentialData(SingleFileData):
         stream.seek(0)
         self.md5 = md5_from_filelike(stream)
 
-    def store(self):
+    def store(self, **kwargs):
         """Store the node verifying first that all required attributes are set.
 
         :raises :py:exc:`~aiida.common.StoringNotAllowed`: if no valid element has been defined.
@@ -64,7 +64,7 @@ class PseudoPotentialData(SingleFileData):
         except ValueError as exception:
             raise StoringNotAllowed(exception) from exception
 
-        return super().store()
+        return super().store(**kwargs)
 
     @property
     def element(self) -> typing.Union[str, None]:

--- a/tests/data/pseudo/test_pseudo.py
+++ b/tests/data/pseudo/test_pseudo.py
@@ -6,6 +6,8 @@ import pytest
 
 from aiida.common.files import md5_from_filelike
 from aiida.common.exceptions import ModificationNotAllowed, StoringNotAllowed
+from aiida.common.links import LinkType
+from aiida.orm import CalcJobNode
 
 from aiida_pseudo.data.pseudo import PseudoPotentialData
 
@@ -90,3 +92,14 @@ def test_md5():
 
     with pytest.raises(ModificationNotAllowed, match='the attributes of a stored entity are immutable'):
         pseudo.md5 = md5
+
+
+@pytest.mark.usefixtures('clear_db')
+def test_store_indirect():
+    """Test the `PseudoPotentialData.store` method when called indirectly because its is an input."""
+    pseudo = PseudoPotentialData(io.BytesIO(b'pseudo'))
+    pseudo.element = 'Ar'
+
+    node = CalcJobNode()
+    node.add_incoming(pseudo, link_type=LinkType.INPUT_CALC, link_label='pseudo')
+    node.store_all()


### PR DESCRIPTION
Fixes #9 

The `Node.store` method requires keyword arguments to be passable but
the `PseudoPotentialData.store` signature didn't allow any. This could
cause a crash when the data type was used unstored as an input to a
process.