### PR TITLE
Add support for PseudoDojo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.6, 3.7, 3.8]
+                python-version: [3.6, 3.7, 3.8, 3.9]
 
         services:
             rabbitmq:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change log
 
+## 0.3.0
+
+### Features
+- Add support for Python 3.9 [[#21]](https://github.com/aiidateam/aiida-pseudo/pull/21)
+- `RecommendedCutoffMixin`: add concept of stringency levels [[#20]](https://github.com/aiidateam/aiida-pseudo/pull/20)
+- `UpfData`: automatically parse the Z valence from the file [[#24]](https://github.com/aiidateam/aiida-pseudo/pull/24)
+
+### Fixes
+- `PseudoPotentialFamily.get_pseudos`: maintain structure kind names [[#20]](https://github.com/aiidateam/aiida-pseudo/pull/20)
+
+
 ## 0.2.0
 
 ### Changes

--- a/aiida_pseudo/__init__.py
+++ b/aiida_pseudo/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """AiiDA plugin that simplifies working with pseudo potentials."""
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/aiida_pseudo/cli/__init__.py
+++ b/aiida_pseudo/cli/__init__.py
@@ -7,6 +7,6 @@ import click_completion
 click_completion.init()
 
 from .root import cmd_root
-from .install import cmd_install, cmd_install_family, cmd_install_sssp
+from .install import cmd_install, cmd_install_family, cmd_install_sssp, cmd_install_pseudo_dojo
 from .list import cmd_list
 from .show import cmd_show

--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -248,12 +248,17 @@ def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_
                     echo.echo_critical(msg)
 
                 for stringency, element_cutoffs in values['hints'].items():
+<<<<<<< HEAD
 
                     if cutoffs.get(stringency, None) is None:
                         cutoffs[stringency] = {}
 
                     # All supported PseudoDojo potentials are NC, so we take dual of 8.0
                     cutoffs[stringency][element] = {
+=======
+                    # All supported PseudoDojo potentials are NC, so we take dual of 8.0
+                    cutoffs.setdefault(stringency, {})[element] = {
+>>>>>>> Add support for Pseudo Dojo pseudopotential families
                         'cutoff_wfc': element_cutoffs['ecut'],
                         'cutoff_rho': element_cutoffs['ecut'] * 8.0
                     }

--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -6,15 +6,16 @@ import shutil
 import tempfile
 
 import click
-
-from aiida.cmdline.utils import decorators, echo
 from aiida.cmdline.params import options as options_core
 from aiida.cmdline.params import types
+from aiida.cmdline.utils import decorators, echo
 
 from .params import options
 from .root import cmd_root
 
 URL_SSSP_BASE = 'https://legacy-archive.materialscloud.org/file/2018.0001/v4/'
+URL_PSEUDODOJO_BASE = 'http://www.pseudo-dojo.org/pseudos/'
+URL_PSEUDODOJO_METADATA_BASE = 'https://raw.githubusercontent.com/abinit/pseudo_dojo/master/pseudo_dojo/pseudos/'
 
 
 @cmd_root.group('install')
@@ -79,12 +80,11 @@ def cmd_install_sssp(version, functional, protocol, traceback):
     """
     # pylint: disable=too-many-locals
     import requests
-
     from aiida.common.files import md5_file
     from aiida.orm import Group, QueryBuilder
-
     from aiida_pseudo import __version__
     from aiida_pseudo.groups.family import SsspConfiguration, SsspFamily
+
     from .utils import attempt, create_family_from_archive
 
     configuration = SsspConfiguration(version, functional, protocol)
@@ -138,5 +138,126 @@ def cmd_install_sssp(version, functional, protocol, traceback):
 
         family.description = description
         family.set_cutoffs({'normal': cutoffs})
+
+        echo.echo_success(f'installed `{label}` containing {family.count()} pseudo potentials')
+
+
+@cmd_install.command('pseudo-dojo')
+@options.VERSION(type=click.Choice(['03', '04']), default='04')
+@options.FUNCTIONAL(type=click.Choice(['pbe', 'pbesol', 'lda']), default='pbe')
+@options.RELATIVISTIC(type=click.Choice(['sr', 'sr3plus', 'fr']), default='sr')
+@options.PROTOCOL(type=click.Choice(['standard', 'stringent']), default='standard')
+@options.PSEUDO_FORMAT(type=click.Choice(['psp8', 'upf', 'psml']), default='psp8')
+@options.TRACEBACK()
+@decorators.with_dbenv()
+def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_format, traceback):
+    """Install a PseudoDojo configuration.
+
+    The PseudoDojo configuration will be automatically downloaded from pseudo-dojo.org to create a new
+    `PseudoDojoFamily` subclass instance based on the specified pseudopotential format.
+    """
+    # pylint: disable=too-many-locals,too-many-arguments,too-many-statements
+    import requests
+    from aiida.common.files import md5_file
+    from aiida.orm import Group, QueryBuilder
+    from aiida_pseudo import __version__
+    from aiida_pseudo.groups.family import (
+        PseudoDojoConfiguration, PseudoDojoPsmlFamily, PseudoDojoPsp8Family, PseudoDojoUpfFamily
+    )
+
+    from .utils import attempt, create_family_from_archive
+
+    cls_mapping = {
+        'psp8': PseudoDojoPsp8Family,
+        'psml': PseudoDojoPsmlFamily,
+        'upf': PseudoDojoUpfFamily,
+    }
+
+    metadata_urls = {
+        'nc-sr-04_pbe_standard': 'ONCVPSP-PBE-PDv0.4/standard.djson',
+        'nc-sr-04_pbe_stringent': 'ONCVPSP-PBE-PDv0.4/stringent.djson',
+        'nc-sr-04_pbesol_standard': 'ONCVPSP-PBEsol-PDv0.4/standard.djson',
+        'nc-sr-04_pbesol_stringent': 'ONCVPSP-PBEsol-PDv0.4/stringent.djson',
+        # 'nc-fr-04_pbe_standard': 'ONCVPSP-PBE-FR-PDv0.4/standard.djson',  # md5 does not match
+        # 'nc-fr-04_pbe_stringent': 'ONCVPSP-PBE-FR-PDv0.4/stringent.djson'  # missing elements
+    }
+
+    try:
+        cls = cls_mapping[pseudo_format]
+    except KeyError:
+        echo.echo_critical(f'{pseudo_format} is not a valid PseudoDojo pseudopotential format')
+
+    configuration = PseudoDojoConfiguration(version, functional, relativistic, protocol)
+    label = cls.format_configuration_label(configuration)
+    description = f'PseudoDojo v{version} {functional} {relativistic} {protocol} {pseudo_format} ' + \
+        f'installed with aiida-pseudo v{__version__}'
+
+    if configuration not in cls.valid_configurations:
+        echo.echo_critical(
+            f'{version} {functional} {relativistic} {protocol}is not a valid PseudoDojo configuration for {cls}'
+        )
+
+    if QueryBuilder().append(cls, filters={'label': label}).first():
+        echo.echo_critical(f'{cls.__name__}<{label}> is already installed')
+
+    with tempfile.TemporaryDirectory() as dirpath:
+
+        if relativistic == 'sr3plus':
+            url_archive = f'{URL_PSEUDODOJO_BASE}/nc-sr-{version}-3plus_{functional}_{protocol}_{pseudo_format}.tgz'
+        else:
+            url_archive = f'{URL_PSEUDODOJO_BASE}/nc-{relativistic}-{version}_{functional}_{protocol}_' + \
+                f'{pseudo_format}.tgz'
+
+        filepath_archive = os.path.join(dirpath, 'archive.tgz')
+
+        with attempt('downloading selected pseudo potentials archive... ', include_traceback=traceback):
+            response = requests.get(url_archive)
+            response.raise_for_status()
+            with open(filepath_archive, 'wb') as handle:
+                handle.write(response.content)
+                handle.flush()
+                description += f'\nArchive pseudos md5: {md5_file(filepath_archive)}'
+
+        with attempt('unpacking archive and parsing pseudos... ', include_traceback=traceback):
+            family = create_family_from_archive(cls, label, filepath_archive)
+
+        family.description = description
+        label_metadata = f'nc-{relativistic}-{version}_{functional}_{protocol}'
+
+        if label_metadata in metadata_urls:
+            url_metadata = f'{URL_PSEUDODOJO_METADATA_BASE}/{metadata_urls[label_metadata]}'
+            filepath_metadata = os.path.join(dirpath, 'metadata.json')
+
+            with attempt('downloading selected pseudo potentials metadata... ', include_traceback=traceback):
+                response = requests.get(url_metadata)
+                response.raise_for_status()
+                with open(filepath_metadata, 'a+b') as handle:
+                    handle.write(response.content)
+                    handle.flush()
+                    handle.seek(0)
+                    metadata = json.load(handle)
+                    description += f'\nPseudo metadata md5: {md5_file(filepath_metadata)}'
+
+            cutoffs = {}
+
+            for element, values in metadata['pseudos_metadata'].items():
+
+                if family.get_pseudo(element).md5 != values['md5']:
+                    Group.objects.delete(family.pk)
+                    msg = f"md5 of pseudo for element {element} does not match that of the metadata {values['md5']}"
+                    echo.echo_critical(msg)
+
+                for stringency, element_cutoffs in values['hints'].items():
+
+                    if cutoffs.get(stringency, None) is None:
+                        cutoffs[stringency] = {}
+
+                    # All supported PseudoDojo potentials are NC, so we take dual of 8.0
+                    cutoffs[stringency][element] = {
+                        'cutoff_wfc': element_cutoffs['ecut'],
+                        'cutoff_rho': element_cutoffs['ecut'] * 8.0
+                    }
+
+            family.set_cutoffs(cutoffs=cutoffs, default_stringency='normal')
 
         echo.echo_success(f'installed `{label}` containing {family.count()} pseudo potentials')

--- a/aiida_pseudo/cli/params/options.py
+++ b/aiida_pseudo/cli/params/options.py
@@ -7,18 +7,40 @@ import click
 from aiida.cmdline.params.options import OverridableOption
 from .types import PseudoPotentialFamilyTypeParam
 
-__all__ = ('VERSION', 'FUNCTIONAL', 'PROTOCOL', 'TRACEBACK', 'FAMILY_TYPE', 'ARCHIVE_FORMAT')
+__all__ = (
+    'VERSION', 'FUNCTIONAL', 'RELATIVISTIC', 'PROTOCOL', 'PSEUDO_FORMAT', 'TRACEBACK', 'FAMILY_TYPE', 'ARCHIVE_FORMAT'
+)
 
 VERSION = OverridableOption(
-    '-v', '--version', type=click.STRING, required=False, help='Select the version of the SSSP configuration.'
+    '-v', '--version', type=click.STRING, required=False, help='Select the version of the installed configuration.'
 )
 
 FUNCTIONAL = OverridableOption(
-    '-f', '--functional', type=click.STRING, required=False, help='Select the functional of the SSSP configuration.'
+    '-x',
+    '--functional',
+    type=click.STRING,
+    required=False,
+    help='Select the functional of the installed configuration.'
+)
+
+RELATIVISTIC = OverridableOption(
+    '-r',
+    '--relativistic',
+    type=click.STRING,
+    required=False,
+    help='Select the type of relativistic effects included in the installed configuration.'
 )
 
 PROTOCOL = OverridableOption(
-    '-p', '--protocol', type=click.STRING, required=False, help='Select the protocol of the SSSP configuration.'
+    '-p', '--protocol', type=click.STRING, required=False, help='Select the protocol of the installed configuration.'
+)
+
+PSEUDO_FORMAT = OverridableOption(
+    '-f',
+    '--pseudo-format',
+    type=click.STRING,
+    required=True,
+    help='Select the pseudopotential file format of the installed configuration.'
 )
 
 TRACEBACK = OverridableOption(

--- a/aiida_pseudo/data/pseudo/upf.py
+++ b/aiida_pseudo/data/pseudo/upf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Module for data plugin to represent a pseudo potential in UPF format."""
 import re
-from typing import BinaryIO
+from typing import BinaryIO, Union
 
 from .pseudo import PseudoPotentialData
 
@@ -10,29 +10,57 @@ __all__ = ('UpfData',)
 REGEX_ELEMENT_V1 = re.compile(r"""(?P<element>[a-zA-Z]{1,2})\s+Element""")
 REGEX_ELEMENT_V2 = re.compile(r"""\s*element\s*=\s*['"]\s*(?P<element>[a-zA-Z]{1,2})\s*['"].*""")
 
+PATTERN_FLOAT = r'[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?'
+REGEX_Z_VALENCE_V1 = re.compile(r"""(?P<z_valence>""" + PATTERN_FLOAT + r""")\s+Z valence""")
+REGEX_Z_VALENCE_V2 = re.compile(r"""\s*z_valence\s*=\s*['"]\s*(?P<z_valence>""" + PATTERN_FLOAT + r""")\s*['"].*""")
 
-def parse_element(stream: BinaryIO):
+
+def parse_element(content: str):
     """Parse the content of the UPF file to determine the element.
 
     :param stream: a filelike object with the binary content of the file.
     :return: the symbol of the element following the IUPAC naming standard.
     """
-    lines = stream.read().decode('utf-8')
-    match = REGEX_ELEMENT_V2.search(lines)
+    for regex in [REGEX_ELEMENT_V2, REGEX_ELEMENT_V1]:
 
-    if match:
-        return match.group('element')
+        match = regex.search(content)
 
-    match = REGEX_ELEMENT_V1.search(lines)
+        if match:
+            return match.group('element')
 
-    if match:
-        return match.group('element')
+    raise ValueError(f'could not parse the element from the UPF content: {content}')
 
-    raise ValueError('could not parse the element from the UPF content.')
+
+def parse_z_valence(content: str) -> int:
+    """Parse the content of the UPF file to determine the Z valence.
+
+    :param stream: a filelike object with the binary content of the file.
+    :return: the Z valence.
+    """
+    for regex in [REGEX_Z_VALENCE_V2, REGEX_Z_VALENCE_V1]:
+
+        match = regex.search(content)
+
+        if match:
+            z_valence = match.group('z_valence')
+
+            try:
+                z_valence = float(z_valence)
+            except ValueError as exception:
+                raise ValueError(f'parsed value for the Z valence `{z_valence}` is not a valid number.') from exception
+
+            if int(z_valence) != z_valence:
+                raise ValueError(f'parsed value for the Z valence `{z_valence}` is not an integer.')
+
+            return int(z_valence)
+
+    raise ValueError(f'could not parse the Z valence from the UPF content: {content}')
 
 
 class UpfData(PseudoPotentialData):
     """Data plugin to represent a pseudo potential in UPF format."""
+
+    _key_z_valence = 'z_valence'
 
     def set_file(self, stream: BinaryIO, filename: str = None, **kwargs):  # pylint: disable=arguments-differ
         """Set the file content.
@@ -42,6 +70,30 @@ class UpfData(PseudoPotentialData):
         :raises ValueError: if the element symbol is invalid.
         """
         stream.seek(0)
-        self.element = parse_element(stream)
+
+        content = stream.read().decode('utf-8')
+        self.element = parse_element(content)
+        self.z_valence = parse_z_valence(content)
+
         stream.seek(0)
         super().set_file(stream, filename, **kwargs)
+
+    @property
+    def z_valence(self) -> Union[int, None]:
+        """Return the Z valence.
+
+        :return: the Z valence.
+        """
+        return self.get_attribute(self._key_z_valence, None)
+
+    @z_valence.setter
+    def z_valence(self, value: int):
+        """Set the Z valence.
+
+        :param value: the Z valence.
+        :raises ValueError: if the value is not a positive integer.
+        """
+        if not isinstance(value, int) or value < 0:
+            raise ValueError(f'`{value}` is not a positive integer')
+
+        self.set_attribute(self._key_z_valence, value)

--- a/aiida_pseudo/groups/family/__init__.py
+++ b/aiida_pseudo/groups/family/__init__.py
@@ -2,10 +2,13 @@
 # pylint: disable=undefined-variable
 """Module with group plugins to represent pseudo potential families."""
 from .pseudo import *
+from .pseudo_dojo import *
 from .psf import *
 from .psml import *
 from .psp8 import *
 from .sssp import *
 from .upf import *
 
-__all__ = (pseudo.__all__ + psf.__all__ + psml.__all__ + psp8.__all__ + sssp.__all__ + upf.__all__)
+__all__ = (
+    pseudo.__all__ + pseudo_dojo.__all__ + psf.__all__ + psml.__all__ + psp8.__all__ + sssp.__all__ + upf.__all__
+)

--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""Subclass of `PseudoPotentialFamily` designed to represent a PseudoDojo configuration."""
+from collections import namedtuple
+from typing import Sequence
+
+from .pseudo import PseudoPotentialFamily
+from .psml import PsmlFamily
+from .psp8 import Psp8Family
+from .upf import UpfFamily
+
+__all__ = (
+    'PseudoDojoConfiguration', 'PseudoDojoFamily', 'PseudoDojoPsp8Family', 'PseudoDojoUpfFamily', 'PseudoDojoPsmlFamily'
+)
+
+PseudoDojoConfiguration = namedtuple('PseudoDojoConfiguration', ['version', 'functional', 'relativistic', 'protocol'])
+
+
+class PseudoDojoFamily(PseudoPotentialFamily):
+    """Subclass of `PseudoPotentialFamily` designed to represent an PseudoDojo configuration.
+
+    The `PseudoDojoFamily` is essentially a `PseudoPotentialFamily` with some additional constraints. It can only be
+    used to contain the pseudo potentials and corresponding metadata of an official PseudoDojo configuration.
+    """
+
+    _pseudo_format = None
+
+    label_template = 'PseudoDojo/{version}/{functional}/{relativistic}/{protocol}/{pseudo_format}'
+    default_configuration = PseudoDojoConfiguration('04', 'pbe', 'sr', 'standard')
+    invalid_configurations = ()
+    valid_configurations = (
+        PseudoDojoConfiguration('03', 'pbe', 'sr', 'standard'),
+        PseudoDojoConfiguration('03', 'pbe', 'sr', 'stringent'),
+        PseudoDojoConfiguration('03', 'pbesol', 'sr', 'standard'),
+        PseudoDojoConfiguration('03', 'pbesol', 'sr', 'stringent'),
+        PseudoDojoConfiguration('03', 'lda', 'sr', 'standard'),
+        PseudoDojoConfiguration('03', 'lda', 'sr', 'stringent'),
+        PseudoDojoConfiguration('04', 'pbe', 'sr', 'standard'),
+        PseudoDojoConfiguration('04', 'pbe', 'sr', 'stringent'),
+        PseudoDojoConfiguration('04', 'pbesol', 'sr', 'standard'),
+        PseudoDojoConfiguration('04', 'pbesol', 'sr', 'stringent'),
+        PseudoDojoConfiguration('04', 'lda', 'sr', 'standard'),
+        PseudoDojoConfiguration('04', 'lda', 'sr', 'stringent'),
+        PseudoDojoConfiguration('04', 'pbe', 'sr3plus', 'standard'),
+        PseudoDojoConfiguration('04', 'pbe', 'fr', 'standard'),
+        PseudoDojoConfiguration('04', 'pbe', 'fr', 'stringent'),
+        PseudoDojoConfiguration('04', 'pbesol', 'fr', 'standard'),
+        PseudoDojoConfiguration('04', 'pbesol', 'fr', 'stringent'),
+    )
+
+    @classmethod
+    def get_pseudo_format(cls) -> str:
+        """Return the lower case string representation of the pseudopotential format."""
+        from aiida.plugins.entry_point import get_entry_point_from_class
+
+        if cls._pseudo_format is None:
+            pseudo_type = cls._pseudo_type  # pylint: disable=protected-access
+            _, entry_point = get_entry_point_from_class(pseudo_type.__module__, pseudo_type.__name__)
+            cls._pseudo_format = entry_point.name.split('.')[-1]
+
+        return cls._pseudo_format
+
+    @classmethod
+    def get_valid_labels(cls) -> Sequence[str]:
+        """Return the tuple of labels of all valid PseudoDojo configurations."""
+        configurations = set(cls.valid_configurations) - set(cls.invalid_configurations)
+        return tuple(cls.format_configuration_label(configuration) for configuration in configurations)
+
+    @classmethod
+    def format_configuration_label(cls, configuration: PseudoDojoConfiguration) -> str:
+        """Format a label for an `PseudoDojoFamily` with the required syntax.
+
+        :param configuration: the PseudoDojo configuration
+        :return: label
+        """
+        return cls.label_template.format(
+            version=configuration.version,
+            functional=configuration.functional,
+            relativistic=configuration.relativistic,
+            protocol=configuration.protocol,
+            pseudo_format=cls.get_pseudo_format()
+        )
+
+    def __init__(self, label=None, **kwargs):
+        """Construct a new instance, validating that the label matches the required format."""
+        if label not in self.get_valid_labels():
+            raise ValueError(f'the label `{label}` is not a valid PseudoDojo configuration label.')
+
+        super().__init__(label=label, **kwargs)
+
+
+class PseudoDojoPsp8Family(PseudoDojoFamily, Psp8Family):
+    """Subclass of `PseudoDojoFamily` and `Psp8Family` to represent a PseudoDojo configuration with PSP8 pseudos.
+
+    The `PseudoDojoPsp8Family` is essentially a `Psp8Family` with some additional constraints. It can only be used to
+    contain the pseudo potentials and corresponding metadata of an official PSP8 PseudoDojo configuration.
+    """
+
+
+class PseudoDojoUpfFamily(PseudoDojoFamily, UpfFamily):
+    """Subclass of `PseudoDojoFamily` and `UpfFamily` to represent a PseudoDojo configuration with UPF pseudos.
+
+    The `PseudoDojoUpfFamily` is essentially a `UpfFamily` with some additional constraints. It can only be used to
+    contain the pseudo potentials and corresponding metadata of an official upf
+    PseudoDojo configuration.
+    """
+
+
+class PseudoDojoPsmlFamily(PseudoDojoFamily, PsmlFamily):
+    """Subclass of `PseudoDojoFamily` and `PsmlFamily` to represent a PseudoDojo configuration with PSML pseudos.
+
+    The `PseudoDojoPsmlFamily` is essentially a `PsmlFamily` with some additional constraints. It can only be used to
+    contain the pseudo potentials and corresponding metadata of an official PSML PseudoDojo configuration.
+    """
+
+    invalid_configurations = (
+        PseudoDojoConfiguration('03', 'pbe', 'sr', 'standard'),
+        PseudoDojoConfiguration('03', 'pbe', 'sr', 'stringent'),
+        PseudoDojoConfiguration('03', 'pbesol', 'sr', 'standard'),
+        PseudoDojoConfiguration('03', 'pbesol', 'sr', 'stringent'),
+        PseudoDojoConfiguration('03', 'lda', 'sr', 'standard'),
+        PseudoDojoConfiguration('03', 'lda', 'sr', 'stringent'),
+    )

--- a/aiida_pseudo/groups/family/psml.py
+++ b/aiida_pseudo/groups/family/psml.py
@@ -2,6 +2,7 @@
 """Group to represent a pseudo potential family with pseudos in PSML format."""
 from aiida.plugins import DataFactory
 
+from ..mixins import RecommendedCutoffMixin
 from .pseudo import PseudoPotentialFamily
 
 __all__ = ('PsmlFamily',)
@@ -9,7 +10,7 @@ __all__ = ('PsmlFamily',)
 PsmlData = DataFactory('pseudo.psml')  # pylint: disable=invalid-name
 
 
-class PsmlFamily(PseudoPotentialFamily):
+class PsmlFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
     """Group to represent a pseudo potential family with pseudos in PSML format."""
 
     _pseudo_type = PsmlData

--- a/aiida_pseudo/groups/family/psp8.py
+++ b/aiida_pseudo/groups/family/psp8.py
@@ -2,6 +2,7 @@
 """Group to represent a pseudo potential family with pseudos in Psp8 format."""
 from aiida.plugins import DataFactory
 
+from ..mixins import RecommendedCutoffMixin
 from .pseudo import PseudoPotentialFamily
 
 __all__ = ('Psp8Family',)
@@ -9,7 +10,7 @@ __all__ = ('Psp8Family',)
 Psp8Data = DataFactory('pseudo.psp8')  # pylint: disable=invalid-name
 
 
-class Psp8Family(PseudoPotentialFamily):
+class Psp8Family(RecommendedCutoffMixin, PseudoPotentialFamily):
     """Group to represent a pseudo potential family with pseudos in Psp8 format."""
 
     _pseudo_type = Psp8Data

--- a/setup.json
+++ b/setup.json
@@ -27,6 +27,10 @@
         ],
         "aiida.groups": [
             "pseudo.family = aiida_pseudo.groups.family.pseudo:PseudoPotentialFamily",
+            "pseudo.family.pseudo_dojo = aiida_pseudo.groups.family.pseudo_dojo:PseudoDojoFamily",
+            "pseudo.family.pseudo_dojo.psml = aiida_pseudo.groups.family.pseudo_dojo:PseudoDojoPsmlFamily",
+            "pseudo.family.pseudo_dojo.psp8 = aiida_pseudo.groups.family.pseudo_dojo:PseudoDojoPsp8Family",
+            "pseudo.family.pseudo_dojo.upf = aiida_pseudo.groups.family.pseudo_dojo:PseudoDojoUpfFamily",
             "pseudo.family.psf = aiida_pseudo.groups.family.psf:PsfFamily",
             "pseudo.family.psml = aiida_pseudo.groups.family.psml:PsmlFamily",
             "pseudo.family.psp8 = aiida_pseudo.groups.family.psp8:Psp8Family",

--- a/setup.json
+++ b/setup.json
@@ -10,7 +10,8 @@
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8"
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9"
     ],
     "description": "AiiDA plugin that simplifies working with pseudo potentials",
     "entry_points": {

--- a/setup.json
+++ b/setup.json
@@ -54,5 +54,5 @@
     "license": "MIT License",
     "name": "aiida-pseudo",
     "url": "https://github.com/aiidateam/aiida-pseudo",
-    "version": "0.2.0"
+    "version": "0.3.0"
 }

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -4,7 +4,7 @@ import pytest
 
 from aiida.orm import QueryBuilder
 
-from aiida_pseudo.cli import cmd_install_family, cmd_install_sssp
+from aiida_pseudo.cli import cmd_install_family, cmd_install_sssp, cmd_install_pseudo_dojo
 from aiida_pseudo.groups.family import PseudoPotentialFamily, UpfFamily
 
 
@@ -83,4 +83,23 @@ def test_install_sssp(run_cli_command):
     assert 'Pseudo metadata md5: 0d5d6c2c840383c7c4fc3a99b5dc3001' in family.description
 
     result = run_cli_command(cmd_install_sssp, raises=SystemExit)
+    assert 'is already installed' in result.output
+
+
+@pytest.mark.usefixtures('clear_db')
+def test_install_pseudo_dojo(run_cli_command):
+    """Test the `aiida-pseudo install pseudo-dojo` command."""
+    from aiida_pseudo import __version__
+    from aiida_pseudo.groups.family import PseudoDojoFamily
+
+    result = run_cli_command(cmd_install_pseudo_dojo)
+    assert 'installed `PseudoDojo/' in result.output
+    assert QueryBuilder().append(PseudoDojoFamily).count() == 1
+
+    family = QueryBuilder().append(PseudoDojoFamily).one()[0]
+    assert family.get_cutoffs is not None
+    assert f'PseudoDojo v04 pbe sr standard psp8 installed with aiida-pseudo v{__version__}' in family.description
+    assert 'Archive pseudos md5: a43737369e8a0a4417ccf364397298b3' in family.description
+
+    result = run_cli_command(cmd_install_pseudo_dojo, raises=SystemExit)
     assert 'is already installed' in result.output

--- a/tests/data/pseudo/test_upf.py
+++ b/tests/data/pseudo/test_upf.py
@@ -6,6 +6,7 @@ import pytest
 
 from aiida.common.exceptions import ModificationNotAllowed
 from aiida_pseudo.data.pseudo import UpfData
+from aiida_pseudo.data.pseudo.upf import parse_z_valence
 
 
 @pytest.mark.usefixtures('clear_db')
@@ -38,3 +39,21 @@ def test_set_file(filepath_pseudos, get_pseudo_potential_data):
 
         with pytest.raises(ModificationNotAllowed):
             pseudo.set_file(handle)
+
+
+@pytest.mark.parametrize(
+    'content', (
+        'z_valence="1"',
+        'z_valence="1.0"',
+        'z_valence="1.000"',
+        'z_valence="1.00E+01"',
+        'z_valence="1500."',
+        "z_valence='1.0'",
+        'z_valence="    1"',
+        'z_valence="1    "',
+        '1.0     Z valence',
+    )
+)
+def test_parse_z_valence(content):
+    """Test the ``parse_z_valence`` method."""
+    assert parse_z_valence(content)

--- a/tests/fixtures/pseudos/upf/Ar.upf
+++ b/tests/fixtures/pseudos/upf/Ar.upf
@@ -8,6 +8,7 @@
         author="sphuber"
         date="200411"
         element="Ar"
+        z_valence="1.0"
         pseudo_type="NC"
     />
 </UPF>

--- a/tests/fixtures/pseudos/upf/He.upf
+++ b/tests/fixtures/pseudos/upf/He.upf
@@ -8,6 +8,7 @@
         author="sphuber"
         date="200411"
         element="He"
+        z_valence="1.0"
         pseudo_type="NC"
     />
 </UPF>

--- a/tests/fixtures/pseudos/upf/Kr.upf
+++ b/tests/fixtures/pseudos/upf/Kr.upf
@@ -8,6 +8,7 @@
         author="sphuber"
         date="200411"
         element="Kr"
+        z_valence="1.0"
         pseudo_type="NC"
     />
 </UPF>

--- a/tests/fixtures/pseudos/upf/Ne.upf
+++ b/tests/fixtures/pseudos/upf/Ne.upf
@@ -8,6 +8,7 @@
         author="sphuber"
         date="200411"
         element="Ne"
+        z_valence="1.0"
         pseudo_type="NC"
     />
 </UPF>

--- a/tests/fixtures/pseudos/upf/Rn.upf
+++ b/tests/fixtures/pseudos/upf/Rn.upf
@@ -8,6 +8,7 @@
         author="sphuber"
         date="200411"
         element="Rn"
+        z_valence="1.0"
         pseudo_type="NC"
     />
 </UPF>

--- a/tests/groups/family/test_pseudo_dojo.py
+++ b/tests/groups/family/test_pseudo_dojo.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument,pointless-statement
+"""Tests for the `PseudoDojoFamily` subclasses."""
+import pytest
+
+from aiida_pseudo.groups.family import (
+    PseudoDojoConfiguration, PseudoDojoFamily, PseudoDojoPsp8Family, PseudoDojoUpfFamily, PseudoDojoPsmlFamily
+)
+
+
+@pytest.mark.parametrize(['family', 'type_string'], (
+    (PseudoDojoFamily, 'pseudo.family.pseudo_dojo'),
+    (PseudoDojoPsp8Family, 'pseudo.family.pseudo_dojo.psp8'),
+    (PseudoDojoUpfFamily, 'pseudo.family.pseudo_dojo.upf'),
+    (PseudoDojoPsmlFamily, 'pseudo.family.pseudo_dojo.psml'),
+))
+def test_type_string(clear_db, family, type_string):
+    """Verify the `_type_string` class attribute is correctly set to the corresponding entry point name."""
+    assert family._type_string == type_string  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize('family', (PseudoDojoPsp8Family, PseudoDojoUpfFamily, PseudoDojoPsmlFamily))
+def test_default_configuration(family):
+    """Test the `PseudoDojoFamily.default_configuration` class attribute."""
+    assert isinstance(family.default_configuration, PseudoDojoConfiguration)
+
+
+@pytest.mark.parametrize('family', (PseudoDojoPsp8Family, PseudoDojoUpfFamily, PseudoDojoPsmlFamily))
+def test_valid_configurations(family):
+    """Test the `PseudoDojoFamily.valid_configurations` class attribute."""
+    valid_configurations = family.valid_configurations
+    assert isinstance(valid_configurations, tuple)
+
+    for entry in valid_configurations:
+        assert isinstance(entry, PseudoDojoConfiguration)
+
+
+@pytest.mark.parametrize('family', (PseudoDojoPsp8Family, PseudoDojoUpfFamily, PseudoDojoPsmlFamily))
+def test_get_valid_labels(family):
+    """Test the `PseudoDojoFamily.get_valid_labels` class method."""
+    valid_labels = family.get_valid_labels()
+    assert isinstance(valid_labels, tuple)
+
+    for entry in valid_labels:
+        assert isinstance(entry, str)
+
+
+@pytest.mark.parametrize('family', (PseudoDojoPsp8Family, PseudoDojoUpfFamily, PseudoDojoPsmlFamily))
+def test_format_configuration_label(family):
+    """Test the `PseudoDojoFamily.format_configuration_label` class method."""
+    configuration = PseudoDojoConfiguration('04', 'pbe', 'sr', 'standard')
+    pseudo_format = family.get_pseudo_format()
+    assert family.format_configuration_label(configuration) == f'PseudoDojo/04/pbe/sr/standard/{pseudo_format}'
+
+
+@pytest.mark.parametrize('family', (PseudoDojoPsp8Family, PseudoDojoUpfFamily, PseudoDojoPsmlFamily))
+def test_constructor(family):
+    """Test that the `PseudoDojoFamily` constructor validates the label."""
+    with pytest.raises(ValueError, match=r'the label `.*` is not a valid PseudoDojo configuration label'):
+        family()
+
+    with pytest.raises(ValueError, match=r'the label `.*` is not a valid PseudoDojo configuration label'):
+        family(label='SSSP_1.1_PBE_efficiency')
+
+    label = family.format_configuration_label(family.default_configuration)
+    family_instance = family(label=label)
+    assert isinstance(family_instance, family)
+
+
+@pytest.mark.parametrize(
+    'family, pseudo_format', (
+        (PseudoDojoPsp8Family, 'psp8'),
+        (PseudoDojoUpfFamily, 'upf'),
+        (PseudoDojoPsmlFamily, 'psml'),
+    )
+)
+def test_get_pseudo_format(family, pseudo_format):
+    """Test the `PseudoDojoFamily.get_pseudo_format` classmethod."""
+    assert family.get_pseudo_format() == pseudo_format


### PR DESCRIPTION
See #14 for comments on PseudoDojo support.

Since my last comment in #14 , I've changed the structure of the PseudoDojo class files: all PseudoDojo families are now in `pseudodojo.py` instead of cluttering the directory with `pseudodojo_[format].py` files.

~~For some reason, the duplicate file test is not passing even though I have not touched the relevant code in `PseudoPotentialFamily`.~~