### PR TITLE
`PseudoPotentialFamily.get_pseudos`: maintain structure kind names

### DIFF
--- a/aiida_pseudo/groups/family/pseudo.py
+++ b/aiida_pseudo/groups/family/pseudo.py
@@ -254,6 +254,6 @@ class PseudoPotentialFamily(Group):
             raise ValueError('structure should be a `StructureData` instance.')
 
         if structure is not None:
-            elements = [kind.symbol for kind in structure.kinds]
+            return {kind.name: self.get_pseudo(kind.symbol) for kind in structure.kinds}
 
         return {element: self.get_pseudo(element) for element in elements}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,9 @@ def get_pseudo_family(tmpdir, filepath_pseudos):
         :param elements: optional list of elements to include instead of all the available ones
         :return: the pseudo family
         """
+        if elements is not None:
+            elements = {re.sub('[0-9]+', '', element) for element in elements}
+
         dirpath = filepath_pseudos('upf')
         for pseudo in os.listdir(dirpath):
             if elements is None or any([pseudo.startswith(element) for element in elements]):

--- a/tests/groups/family/test_pseudo.py
+++ b/tests/groups/family/test_pseudo.py
@@ -360,3 +360,16 @@ def test_get_pseudos_structure(get_pseudo_family, generate_structure):
     assert isinstance(pseudos, dict)
     for element in elements:
         assert isinstance(pseudos[element], PseudoPotentialData)
+
+
+@pytest.mark.usefixtures('clear_db')
+def test_get_pseudos_structure_kinds(get_pseudo_family, generate_structure):
+    """Test the `PseudoPotentialFamily.get_pseudos` for ``StructureData`` with kind names including digits."""
+    elements = ('Ar1', 'Ar2')
+    structure = generate_structure(elements)
+    family = get_pseudo_family(elements=elements)
+
+    pseudos = family.get_pseudos(structure=structure)
+    assert isinstance(pseudos, dict)
+    for element in elements:
+        assert isinstance(pseudos[element], PseudoPotentialData)


### PR DESCRIPTION
Fixes #91

The method was incorrectly returning a mapping of the pseudos onto the
symbols of the structure's kind, thereby discarding the kind name, which
can often be different from the symbol. For example, `aiida-quantumespresso`
uses kind names that suffix the element symbol with a digit in order to
specify different magnetic kinds.