### PR TITLE
Add support for PseudoDojo PAW pseudos

### DIFF
--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -231,6 +231,19 @@ def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_
                 msg = f'md5 of pseudo for element {element} does not match that of the metadata {md5}'
                 echo.echo_critical(msg)
 
+        elements_to_remove = []
+        for stringency, str_cutoff in cutoffs.items():
+            for element, cutoff in str_cutoff.items():
+                if cutoff['cutoff_wfc'] <= 0 or cutoff['cutoff_rho'] <= 0:
+                    elements_to_remove.append(element)
+        for element in set(elements_to_remove):
+            for stringency in cutoffs:
+                _ = cutoffs[stringency].pop(element)
+            pseudo = family.get_pseudo(element)
+            family.remove_nodes(pseudo)
+            msg = f'invalid cutoffs for element {element}, removing its pseudo (pk: {pseudo.pk}) from the family'
+            echo.echo_warning(msg)
+
         family.description = description
         family.set_cutoffs(cutoffs, default_stringency=default_stringency)
 

--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -66,10 +66,10 @@ class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
         PseudoDojoConfiguration('0.4', 'PBE', 'FR', 'stringent', 'psml'),
         PseudoDojoConfiguration('0.4', 'PBEsol', 'FR', 'standard', 'psml'),
         PseudoDojoConfiguration('0.4', 'PBEsol', 'FR', 'stringent', 'psml'),
-        # PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'standard', 'jthxml'),  # paw families have placeholder cutoffs
-        # PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'stringent', 'jthxml'),
-        # PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'standard', 'jthxml'),
-        # PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'stringent', 'jthxml')
+        PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'standard', 'jthxml'),
+        PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'stringent', 'jthxml'),
+        PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'standard', 'jthxml'),
+        PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'stringent', 'jthxml')
     )
     # yapf: enable
 


### PR DESCRIPTION
Discussed in issue #40 

Because only the Lanthanides are missing cutoffs in the PseudoDojo PAW families, which in general are not available in the other PseudoDojo families, I simply remove the elements with missing (placeholder, value `-1`) cutoffs from the `PseudoDojoFamily` during installation and warn the user that I'm doing it.