### PR TITLE
Add support for PseudoDojo PAW pseudos (alternative)

### DIFF
--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -241,8 +241,8 @@ def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_
                 echo.echo_critical(msg)
 
         # The PAW configurations have missing cutoffs for the Lanthanides, which have ben replaced with a placeholder
-        # value of `-1`. We replace these with the maximum cutoff from the same stringency so that these potentials are
-        # still useable, but this should be taken as a _rough_ approximation.
+        # value of `-1`. We replace these with the 1.5 * the maximum cutoff from the same stringency so that these
+        # potentials are still usable, but this should be taken as a _rough_ approximation.
         # We check only the `cutoff_wfc` because `cutoff_rho` is not provided by PseudoDojo and is therefore
         # locally calculated in `PseudoDojoFamily.parse_djrepos_from_archive` as `2.0 * cutoff_wfc` for PAW.
         if configuration in paw_configurations:
@@ -250,16 +250,17 @@ def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_
             for stringency, str_cutoffs in cutoffs.items():
                 adjusted_cutoffs[stringency] = []
                 max_cutoff_wfc = max([str_cutoffs[element]['cutoff_wfc'] for element in str_cutoffs])
+                filler_cutoff_wfc = max_cutoff_wfc * 1.5
                 for element, cutoff in str_cutoffs.items():
                     if cutoff['cutoff_wfc'] <= 0:
-                        cutoffs[stringency][element]['cutoff_wfc'] = max_cutoff_wfc
-                        cutoffs[stringency][element]['cutoff_rho'] = 2.0 * max_cutoff_wfc
+                        cutoffs[stringency][element]['cutoff_wfc'] = filler_cutoff_wfc
+                        cutoffs[stringency][element]['cutoff_rho'] = 2.0 * filler_cutoff_wfc
                         adjusted_cutoffs[stringency].append(element)
 
             for stringency, elements in adjusted_cutoffs.items():
                 msg = f'stringency `{stringency}` has missing recommended cutoffs for elements ' \
-                    f'{", ".join(elements)}: as a substitute, the maximum cutoff of the stringency was set for these ' \
-                    'elements. USE WITH CAUTION!'
+                    f'{", ".join(elements)}: as a substitute, 1.5 * the maximum cutoff of the stringency ' \
+                    'was set for these elements. USE WITH CAUTION!'
                 echo.echo_warning(msg)
 
         family.description = description

--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -237,15 +237,15 @@ def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_
             max_cutoff_rho = max([str_cutoffs[element]['cutoff_rho'] for element in str_cutoffs])
             for element, cutoff in str_cutoffs.items():
                 if cutoff['cutoff_wfc'] <= 0:
-                    cutoffs[stringency][element]['cutoff_wfc'] = max_cutoff_wfc
+                    cutoffs[stringency][element]['cutoff_wfc'] = max_cutoff_wfc * 2.0
                     adjusted_cutoff_elements.append(element)
                 if cutoff['cutoff_rho'] <= 0:
-                    cutoffs[stringency][element]['cutoff_rho'] = max_cutoff_rho
+                    cutoffs[stringency][element]['cutoff_rho'] = max_cutoff_rho * 2.0
                     adjusted_cutoff_elements.append(element)
 
         for element in set(adjusted_cutoff_elements):
-            msg = f'element {element} had invalid cutoff(s) which were modified to the maximum cutoff value of the ' \
-                'same stringency'
+            msg = f'element {element} had invalid cutoff(s) which were modified to two times the maximum cutoff ' \
+                'value of the same stringency'
             echo.echo_warning(msg)
 
         family.description = description

--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -180,6 +180,15 @@ def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_
         'upf': UpfData,
     }
 
+    # yapf: disable
+    paw_configurations = (
+        PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'standard', 'jthxml'),
+        PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'stringent', 'jthxml'),
+        PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'standard', 'jthxml'),
+        PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'stringent', 'jthxml')
+    )
+    # yapf: enable
+
     try:
         pseudo_type = pseudo_type_mapping[pseudo_format]
     except KeyError:
@@ -231,22 +240,27 @@ def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_
                 msg = f'md5 of pseudo for element {element} does not match that of the metadata {md5}'
                 echo.echo_critical(msg)
 
-        adjusted_cutoff_elements = []
-        for stringency, str_cutoffs in cutoffs.items():
-            max_cutoff_wfc = max([str_cutoffs[element]['cutoff_wfc'] for element in str_cutoffs])
-            max_cutoff_rho = max([str_cutoffs[element]['cutoff_rho'] for element in str_cutoffs])
-            for element, cutoff in str_cutoffs.items():
-                if cutoff['cutoff_wfc'] <= 0:
-                    cutoffs[stringency][element]['cutoff_wfc'] = max_cutoff_wfc * 2.0
-                    adjusted_cutoff_elements.append(element)
-                if cutoff['cutoff_rho'] <= 0:
-                    cutoffs[stringency][element]['cutoff_rho'] = max_cutoff_rho * 2.0
-                    adjusted_cutoff_elements.append(element)
+        # The PAW configurations have missing cutoffs for the Lanthanides, which have ben replaced with a placeholder
+        # value of `-1`. We replace these with the maximum cutoff from the same stringency so that these potentials are
+        # still useable, but this should be taken as a _rough_ approximation.
+        # We check only the `cutoff_wfc` because `cutoff_rho` is not provided by PseudoDojo and is therefore
+        # locally calculated in `PseudoDojoFamily.parse_djrepos_from_archive` as `2.0 * cutoff_wfc` for PAW.
+        if configuration in paw_configurations:
+            adjusted_cutoffs = {}
+            for stringency, str_cutoffs in cutoffs.items():
+                adjusted_cutoffs[stringency] = []
+                max_cutoff_wfc = max([str_cutoffs[element]['cutoff_wfc'] for element in str_cutoffs])
+                for element, cutoff in str_cutoffs.items():
+                    if cutoff['cutoff_wfc'] <= 0:
+                        cutoffs[stringency][element]['cutoff_wfc'] = max_cutoff_wfc
+                        cutoffs[stringency][element]['cutoff_rho'] = 2.0 * max_cutoff_wfc
+                        adjusted_cutoffs[stringency].append(element)
 
-        for element in set(adjusted_cutoff_elements):
-            msg = f'element {element} had invalid cutoff(s) which were modified to two times the maximum cutoff ' \
-                'value of the same stringency'
-            echo.echo_warning(msg)
+            for stringency, elements in adjusted_cutoffs.items():
+                msg = f'stringency `{stringency}` has missing recommended cutoffs for elements ' \
+                    f'{", ".join(elements)}: as a substitute, the maximum cutoff of the stringency was set for these ' \
+                    'elements. USE WITH CAUTION!'
+                echo.echo_warning(msg)
 
         family.description = description
         family.set_cutoffs(cutoffs, default_stringency=default_stringency)

--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -231,6 +231,23 @@ def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_
                 msg = f'md5 of pseudo for element {element} does not match that of the metadata {md5}'
                 echo.echo_critical(msg)
 
+        adjusted_cutoff_elements = []
+        for stringency, str_cutoffs in cutoffs.items():
+            max_cutoff_wfc = max([str_cutoffs[element]['cutoff_wfc'] for element in str_cutoffs])
+            max_cutoff_rho = max([str_cutoffs[element]['cutoff_rho'] for element in str_cutoffs])
+            for element, cutoff in str_cutoffs.items():
+                if cutoff['cutoff_wfc'] <= 0:
+                    cutoffs[stringency][element]['cutoff_wfc'] = max_cutoff_wfc
+                    adjusted_cutoff_elements.append(element)
+                if cutoff['cutoff_rho'] <= 0:
+                    cutoffs[stringency][element]['cutoff_rho'] = max_cutoff_rho
+                    adjusted_cutoff_elements.append(element)
+
+        for element in set(adjusted_cutoff_elements):
+            msg = f'element {element} had invalid cutoff(s) which were modified to the maximum cutoff value of the ' \
+                'same stringency'
+            echo.echo_warning(msg)
+
         family.description = description
         family.set_cutoffs(cutoffs, default_stringency=default_stringency)
 

--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -206,7 +206,7 @@ class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
         :returns: cutoffs dictionary (in eV) where keys are stringency levels and values are
             {'cutoff_wfc': ..., 'cutoff_rho': ...}
         """
-        dual_mapping = {UpfData: 8.0, Psp8Data: 8.0, PsmlData: 8.0, JthXmlData: 2.0}
+        dual_mapping = {UpfData: 4.0, Psp8Data: 4.0, PsmlData: 4.0, JthXmlData: 2.0}
 
         try:
             dual = dual_mapping[pseudo_type]

--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -66,10 +66,10 @@ class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
         PseudoDojoConfiguration('0.4', 'PBE', 'FR', 'stringent', 'psml'),
         PseudoDojoConfiguration('0.4', 'PBEsol', 'FR', 'standard', 'psml'),
         PseudoDojoConfiguration('0.4', 'PBEsol', 'FR', 'stringent', 'psml'),
-        # PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'standard', 'jthxml'),  # paw families have placeholder cutoffs
-        # PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'stringent', 'jthxml'),
-        # PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'standard', 'jthxml'),
-        # PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'stringent', 'jthxml')
+        PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'standard', 'jthxml'),
+        PseudoDojoConfiguration('1.0', 'PBE', 'SR', 'stringent', 'jthxml'),
+        PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'standard', 'jthxml'),
+        PseudoDojoConfiguration('1.0', 'LDA', 'SR', 'stringent', 'jthxml')
     )
     # yapf: enable
 


### PR DESCRIPTION
Discussed in issue #40 
Alternative to PR #41 

The range of recommended cutoffs in the PseudoDojo PAW families is relatively small (min 10, 10, 10; max 20, 20, 25 for low, normal, high stringency). So, it seems fairly reasonable to replace placeholder cutoff values (i.e. -1) with the maximum for the corresponding stringency. This is an alternative solution to dropping the pseudos entirely, as proposed in #41 