### PR TITLE
`PseudoDojoFamily`: skip repo files with unsupported extension

### DIFF
--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -271,6 +271,7 @@ class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
             if not os.path.isfile(filepath):
                 raise ValueError(f'dirpath `{dirpath}` contains at least one entry that is not a file')
 
+            # Some of the djrepo archives contain extraneous files. Here we skip files with unsupported extensions.
             if filename.split('.')[-1] not in cls._pseudo_repo_file_extensions:
                 warnings.warn(f'filename {filename} does not have a supported extension. Skipping...')
                 continue

--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -4,6 +4,7 @@ import collections
 import json
 import os
 import re
+import warnings
 from typing import Sequence
 
 from aiida.common.exceptions import ParsingError
@@ -28,6 +29,7 @@ class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
     """
 
     _pseudo_types = (UpfData, PsmlData, Psp8Data, JthXmlData)
+    _pseudo_repo_file_extensions = ('djrepo',)
 
     label_template = 'PseudoDojo/{version}/{functional}/{relativistic}/{protocol}/{pseudo_format}'
     default_configuration = PseudoDojoConfiguration('0.4', 'PBE', 'SR', 'standard', 'psp8')
@@ -268,6 +270,10 @@ class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
 
             if not os.path.isfile(filepath):
                 raise ValueError(f'dirpath `{dirpath}` contains at least one entry that is not a file')
+
+            if filename.split('.')[-1] not in cls._pseudo_repo_file_extensions:
+                warnings.warn(f'filename {filename} does not have a supported extension. Skipping...')
+                continue
 
             try:
                 with open(filepath, 'r') as handle:


### PR DESCRIPTION
Fixes #46 

Some of the djrepo archives from the Pseudo Dojo contain extraneous
files with incorrect extensions (e.g. a second file for Ge with
extension `.djrepo_old`). This currently means that installing from this
archive raises a `ValueError` since duplicate elements will be found.

Here we add a check that makes sure the extension of the archive
filename is in a list of supported extensions, currently limited to
`.djrepo`. If the extension is incorrect, a warning is raised and the
file is skipped.