### PR TITLE
CLI: add recommended cutoffs to `aiida-pseudo family show`

### DIFF
--- a/aiida_pseudo/cli/params/options.py
+++ b/aiida_pseudo/cli/params/options.py
@@ -44,6 +44,10 @@ PSEUDO_FORMAT = OverridableOption(
     help='Select the pseudopotential file format of the installed configuration.'
 )
 
+STRINGENCY = OverridableOption(
+    '-s', '--stringency', type=click.STRING, required=False, help='Stringency level for the recommended cutoffs.'
+)
+
 DEFAULT_STRINGENCY = OverridableOption(
     '-s',
     '--default-stringency',

--- a/aiida_pseudo/cli/show.py
+++ b/aiida_pseudo/cli/show.py
@@ -5,22 +5,35 @@ import click
 from aiida.cmdline.params import options as options_core
 from aiida.cmdline.utils import decorators, echo
 
-from .params import PseudoPotentialFamilyParam
+from ..groups.mixins import RecommendedCutoffMixin
+from .params import PseudoPotentialFamilyParam, options
 from .root import cmd_root
 
 
 @cmd_root.command('show')
 @click.argument('family', type=PseudoPotentialFamilyParam(sub_classes=('aiida.groups:pseudo.family',)))
+@options.STRINGENCY()
 @options_core.RAW()
 @decorators.with_dbenv()
-def cmd_show(family, raw):
+def cmd_show(family, stringency, raw):
     """Show details of pseudo potential family."""
     from tabulate import tabulate
 
-    rows = [[pseudo.element, pseudo.filename, pseudo.md5] for pseudo in family.nodes]
-    headers = ['Element', 'Pseudo', 'MD5']
+    if isinstance(family, RecommendedCutoffMixin):
+
+        if stringency is not None and stringency not in family.get_cutoff_stringencies():
+            raise click.BadParameter(f'`{stringency}` is not defined for family `{family}`.', param_hint='stringency')
+
+        headers = ['Element', 'Pseudo', 'MD5', 'Wavefunction (eV)', 'Charge density (eV)']
+        rows = [[
+            pseudo.element, pseudo.filename, pseudo.md5,
+            *family.get_recommended_cutoffs(elements=pseudo.element, stringency=stringency)
+        ] for pseudo in family.nodes]
+    else:
+        headers = ['Element', 'Pseudo', 'MD5']
+        rows = [[pseudo.element, pseudo.filename, pseudo.md5] for pseudo in family.nodes]
 
     if raw:
-        echo.echo(tabulate(sorted(rows), tablefmt='plain'))
+        echo.echo(tabulate(sorted(rows), tablefmt='plain', floatfmt='.1f'))
     else:
-        echo.echo(tabulate(sorted(rows), headers=headers))
+        echo.echo(tabulate(sorted(rows), headers=headers, floatfmt='.1f'))

--- a/aiida_pseudo/groups/family/__init__.py
+++ b/aiida_pseudo/groups/family/__init__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=undefined-variable
 """Module with group plugins to represent pseudo potential families."""
+from .cutoffs import *
 from .pseudo import *
 from .pseudo_dojo import *
 from .sssp import *
 
-__all__ = (pseudo.__all__ + pseudo_dojo.__all__ + sssp.__all__)
+__all__ = (cutoffs.__all__ + pseudo.__all__ + pseudo_dojo.__all__ + sssp.__all__)

--- a/aiida_pseudo/groups/family/cutoffs.py
+++ b/aiida_pseudo/groups/family/cutoffs.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Subclass of ``PseudoPotentialFamily`` designed to represent a family with recommended cutoffs."""
+from ..mixins import RecommendedCutoffMixin
+from .pseudo import PseudoPotentialFamily
+
+__all__ = ('CutoffsFamily',)
+
+
+class CutoffsFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
+    """Subclass of ``PseudoPotentialFamily`` designed to represent a family with recommended cutoffs.
+
+    This is mostly used for testing the functionality around the ``RecommendedCutoffMixin``.
+    """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,5 @@ disable = [
     'bad-continuation',
     'duplicate-code',
     'import-outside-toplevel',
+    'too-many-arguments',
 ]

--- a/setup.json
+++ b/setup.json
@@ -29,6 +29,7 @@
         ],
         "aiida.groups": [
             "pseudo.family = aiida_pseudo.groups.family.pseudo:PseudoPotentialFamily",
+            "pseudo.family.cutoffs = aiida_pseudo.groups.family.cutoffs:CutoffsFamily",
             "pseudo.family.pseudo_dojo = aiida_pseudo.groups.family.pseudo_dojo:PseudoDojoFamily",
             "pseudo.family.sssp = aiida_pseudo.groups.family.sssp:SsspFamily"
         ]

--- a/tests/cli/test_show.py
+++ b/tests/cli/test_show.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
 """Tests for the command `aiida-pseudo show`."""
+from numpy.testing import assert_almost_equal
+
 from aiida.orm import Group
 from aiida_pseudo.cli import cmd_show
-from aiida_pseudo.groups.family import PseudoPotentialFamily
+from aiida_pseudo.groups.family import PseudoPotentialFamily, CutoffsFamily
 
 
 def test_show(clear_db, run_cli_command, get_pseudo_family):
@@ -14,6 +16,42 @@ def test_show(clear_db, run_cli_command, get_pseudo_family):
         assert node.md5 in result.output
         assert node.element in result.output
         assert node.filename in result.output
+
+
+def test_show_recommended_cutoffs(clear_db, run_cli_command, get_pseudo_family):
+    """Test the `aiida-pseudo show` command for a family with recommended cutoffs."""
+    family = get_pseudo_family(cls=CutoffsFamily)
+    cutoffs = {
+        'normal': {},
+        'high': {},
+    }
+
+    for element in family.elements:
+        cutoffs['normal'][element] = {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0}
+        cutoffs['high'][element] = {'cutoff_wfc': 3.0, 'cutoff_rho': 6.0}
+
+    family.set_cutoffs(cutoffs, 'normal')
+
+    # Test the command prints an error for a non-existing stringency
+    result = run_cli_command(cmd_show, [family.label, '--stringency', 'non-existing'], raises=True)
+    assert 'Invalid value for stringency: `non-existing` is not defined' in result.output
+
+    # Test the command for default and explicit stringency
+    for stringency in [None, 'high']:
+
+        if stringency is not None:
+            result = run_cli_command(cmd_show, [family.label, '--stringency', stringency, '--raw'])
+        else:
+            result = run_cli_command(cmd_show, [family.label, '--raw'])
+
+        for index, node in enumerate(sorted(family.nodes, key=lambda pseudo: pseudo.element)):
+            fields = result.output_lines[index].split()
+            cutoffs = family.get_recommended_cutoffs(elements=node.element, stringency=stringency)
+            assert node.element in fields[0]
+            assert node.filename in fields[1]
+            assert node.md5 in fields[2]
+            assert_almost_equal(cutoffs[0], float(fields[3]))
+            assert_almost_equal(cutoffs[1], float(fields[4]))
 
 
 def test_show_argument_type(clear_db, run_cli_command, get_pseudo_family):

--- a/tests/groups/mixins/test_cutoffs.py
+++ b/tests/groups/mixins/test_cutoffs.py
@@ -5,23 +5,7 @@ import copy
 
 import pytest
 
-from aiida.orm.groups import GroupMeta
-from aiida_pseudo.groups.family import PseudoPotentialFamily
-from aiida_pseudo.groups.mixins import RecommendedCutoffMixin
-
-
-class FixtureGroupMeta(GroupMeta):
-    """Meta class for `aiida.orm.groups.Group` to automatically set the `type_string` attribute."""
-
-    def __new__(mcs, name, bases, namespace, **kwargs):  # pylint: disable=bad-mcs-classmethod-argument
-        """Construct new instance of the class."""
-        newcls = GroupMeta.__new__(mcs, name, bases, namespace, **kwargs)  # pylint: disable=too-many-function-args
-        newcls._type_string = 'test'  # pylint: disable=protected-access
-        return newcls
-
-
-class CutoffFamily(RecommendedCutoffMixin, PseudoPotentialFamily, metaclass=FixtureGroupMeta):
-    """Test class for the ``RecommendedCutoffMixin``."""
+from aiida_pseudo.groups.family import CutoffsFamily
 
 
 @pytest.fixture
@@ -45,7 +29,7 @@ def get_cutoffs():
 @pytest.mark.usefixtures('clear_db')
 def test_get_cutoffs_private(get_pseudo_family, get_cutoffs):
     """Test the ``RecommendedCutoffMixin._get_cutoffs`` method."""
-    family = get_pseudo_family(cls=CutoffFamily)
+    family = get_pseudo_family(cls=CutoffsFamily)
     assert family._get_cutoffs() == {}  # pylint: disable=protected-access
 
     family.set_cutoffs(get_cutoffs(family), 'default')
@@ -55,7 +39,7 @@ def test_get_cutoffs_private(get_pseudo_family, get_cutoffs):
 @pytest.mark.usefixtures('clear_db')
 def test_validate_stringency(get_pseudo_family, get_cutoffs):
     """Test the ``RecommendedCutoffMixin.validate_stringency`` method."""
-    family = get_pseudo_family(cls=CutoffFamily)
+    family = get_pseudo_family(cls=CutoffsFamily)
 
     with pytest.raises(ValueError, match=r'stringency `.*` is not defined for this family.'):
         family.validate_stringency('default')
@@ -73,7 +57,7 @@ def test_validate_stringency(get_pseudo_family, get_cutoffs):
 @pytest.mark.usefixtures('clear_db')
 def test_get_default_stringency(get_pseudo_family, get_cutoffs):
     """Test the ``RecommendedCutoffMixin.get_default_stringency`` method."""
-    family = get_pseudo_family(cls=CutoffFamily)
+    family = get_pseudo_family(cls=CutoffsFamily)
 
     with pytest.raises(ValueError, match='no default stringency has been defined.'):
         family.get_default_stringency()
@@ -88,7 +72,7 @@ def test_get_default_stringency(get_pseudo_family, get_cutoffs):
 @pytest.mark.usefixtures('clear_db')
 def test_get_cutoff_stringencies(get_pseudo_family, get_cutoffs):
     """Test the ``RecommendedCutoffMixin.get_cutoff_stringencies`` method."""
-    family = get_pseudo_family(cls=CutoffFamily)
+    family = get_pseudo_family(cls=CutoffsFamily)
     assert family.get_cutoff_stringencies() == ()
 
     stringencies = ('low', 'normal', 'high')
@@ -102,7 +86,7 @@ def test_get_cutoff_stringencies(get_pseudo_family, get_cutoffs):
 def test_set_cutoffs(get_pseudo_family):
     """Test the `RecommendedCutoffMixin.set_cutoffs` method."""
     elements = ['Ar', 'He']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
     cutoffs = {'default': {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}}
     family.set_cutoffs(cutoffs, 'default')
 
@@ -141,7 +125,7 @@ def test_set_cutoffs_auto_default(get_pseudo_family):
     If the cutoffs specified only contain a single set, the `default_stringency` is determined automatically.
     """
     elements = ['Ar']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
     values = {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}
     cutoffs = {'default': values}
 
@@ -157,7 +141,7 @@ def test_set_cutoffs_auto_default(get_pseudo_family):
 def test_get_cutoffs(get_pseudo_family):
     """Test the `RecommendedCutoffMixin.get_cutoffs` method."""
     elements = ['Ar', 'He']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
     cutoffs = {'default': {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}}
 
     with pytest.raises(ValueError, match='no default stringency has been defined.'):
@@ -187,7 +171,7 @@ def test_get_recommended_cutoffs(get_pseudo_family, generate_structure):
             },
         }
     }
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
     family.set_cutoffs(cutoffs, 'default')
     structure = generate_structure(elements=elements)
 


### PR DESCRIPTION
Fixes #51 

Previously, `aiida-pseudo family show` merely shows the element,
filename and md5 of each pseudo contained within a family. Since the
addition of the `RecommendedCutoffMixin`, families can also specify
recommended cutoffs. Here we add these to the output of the command if
the specified family is a subclass of `RecommendedCutoffMixin`.

In order to test this, a generic pseudo potential family class with the
`RecommendedCutoffMixin` is needed. This was already implemented for the
tests of the mixin itself, which created a new group class on the fly
using the `aiida.orm.groups.GroupMeta` meta class to automatically set
the required type strings. This worked for these tests since they didn't
have to be queried for, however, for the `aiida-pseudo family show`
tests, the CLI command will have to query for it and since the mock
class does not have an actual physical entry point, the query fails.

Since dynamically adding an entry point in the setup of the test suite
is not trivial, instead we add an actual `CutoffsFamily` class including
an entry point. This class is designed therefore to be mostly used for
testing purposes.