### PR TITLE
Dependencies: temporarily limit upper version of `sqlalchemy`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -38,7 +38,8 @@
         "aiida-core~=1.4",
         "click~=7.0",
         "click-completion~=0.5",
-        "requests~=2.20"
+        "requests~=2.20",
+        "sqlalchemy<1.4"
     ],
     "extras_require": {
         "pre-commit": [


### PR DESCRIPTION
Fixes #53 

The newly released `sqlalchemy==1.4.0` breaks `sqlalchemy-utils` and so
breaks all the tests. Until the latter releases a fix, we have to put an
upper limit on the `sqlalchemy` dependency.