### PR TITLE
CLI: add `--download-only` option to automatic family install commands

### DIFF
--- a/aiida_pseudo/cli/params/options.py
+++ b/aiida_pseudo/cli/params/options.py
@@ -9,7 +9,7 @@ from .types import PseudoPotentialFamilyTypeParam
 
 __all__ = (
     'VERSION', 'FUNCTIONAL', 'RELATIVISTIC', 'PROTOCOL', 'PSEUDO_FORMAT', 'STRINGENCY', 'DEFAULT_STRINGENCY',
-    'TRACEBACK', 'FAMILY_TYPE', 'ARCHIVE_FORMAT'
+    'TRACEBACK', 'FAMILY_TYPE', 'ARCHIVE_FORMAT', 'UNIT', 'DOWNLOAD_ONLY'
 )
 
 VERSION = OverridableOption(
@@ -81,4 +81,13 @@ UNIT = OverridableOption(
     default='eV',
     show_default=True,
     help='Specify the energy unit of the cutoffs. Must be recognized by the ``UnitRegistry`` of the ``pint`` library.'
+)
+
+DOWNLOAD_ONLY = OverridableOption(
+    '--download-only',
+    is_flag=True,
+    help=(
+        'Only download the pseudopotential files to the current working directory, without installing the '
+        'pseudopotential family.'
+    )
 )

--- a/aiida_pseudo/cli/utils.py
+++ b/aiida_pseudo/cli/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Command line interface utilities."""
 from contextlib import contextmanager
+from pathlib import Path
 
 from aiida.cmdline.utils import echo
 
@@ -31,7 +32,7 @@ def attempt(message, exception_types=Exception, include_traceback=False):
         echo.echo_highlight(' [OK]', color='success', bold=True)
 
 
-def create_family_from_archive(cls, label, filepath_archive, fmt=None, pseudo_type=None):
+def create_family_from_archive(cls, label, filepath_archive: Path, fmt=None, pseudo_type=None):
     """Construct a new pseudo family instance from a tar.gz archive.
 
     .. warning:: the archive should not contain any subdirectories, but just the pseudo potential files.

--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -5,6 +5,8 @@ import json
 import os
 import re
 import warnings
+
+from pathlib import Path
 from typing import Sequence
 
 from aiida.common.exceptions import ParsingError
@@ -314,7 +316,7 @@ class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
         return md5s, cutoffs
 
     @classmethod
-    def parse_djrepos_from_archive(cls, filepath_metadata, fmt=None, pseudo_type=None):
+    def parse_djrepos_from_archive(cls, filepath_metadata: Path, fmt=None, pseudo_type=None):
         """Parse metadata from a djrepo .tgz archive.
 
         .. warning:: the archive should not contain any subdirectories, but just the djrepo files.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,13 @@ def ctx():
 
 
 @pytest.fixture
+def chtmpdir(tmpdir):
+    """Change the current working directory to a temporary directory."""
+    with tmpdir.as_cwd():
+        yield
+
+
+@pytest.fixture
 def run_cli_command():
     """Run a `click` command with the given options.
 


### PR DESCRIPTION
Fixes #63 

The `aiida-pseudo install sssp` and `aiida-pseudo install pseudo-dojo`
automatically download the required files for installing the
corresponding pseudopotential families. Since the entire operation can
sometimes fail, `aiida-pseudo install family` was added in order to
facilitate the manual installation without the automatic download.
Conversely, it may be useful to have the command only download the files
of a particular family, without actually installing them.

The `--download-only` option is added to both automatic family install
commands which will simply write the files to the current working
directory after having downloaded them.