### PR TITLE
CLI: Add `units` option to `aiida-pseudo family cutoffs set`

### DIFF
--- a/aiida_pseudo/cli/params/options.py
+++ b/aiida_pseudo/cli/params/options.py
@@ -72,3 +72,13 @@ FAMILY_TYPE = OverridableOption(
 ARCHIVE_FORMAT = OverridableOption(
     '-F', '--archive-format', type=click.Choice([fmt[0] for fmt in shutil.get_archive_formats()])
 )
+
+UNIT = OverridableOption(
+    '-u',
+    '--unit',
+    type=click.STRING,
+    required=False,
+    default='eV',
+    show_default=True,
+    help='Specify the energy unit of the cutoffs. Must be recognized by the ``UnitRegistry`` of the ``pint`` library.'
+)

--- a/tests/cli/test_family.py
+++ b/tests/cli/test_family.py
@@ -48,6 +48,18 @@ def test_family_cutoffs_set(run_cli_command, get_pseudo_family, tmp_path):
     assert stringency in family.get_cutoff_stringencies()
     assert family.get_cutoffs(stringency) == cutoffs[stringency]
 
+    # Invalid unit
+    unit = 'GME stock'
+    result = run_cli_command(
+        cmd_family_cutoffs_set, [family.label, str(filepath), '-s', stringency, '-u', unit], raises=True
+    )
+    assert 'Error: Invalid value for UNIT:' in result.output
+
+    # Correct unit
+    unit = 'hartree'
+    result = run_cli_command(cmd_family_cutoffs_set, [family.label, str(filepath), '-s', stringency, '-u', unit])
+    assert family.get_cutoffs_unit() == unit
+
 
 def test_family_show(clear_db, run_cli_command, get_pseudo_family):
     """Test the `aiida-pseudo show` command."""


### PR DESCRIPTION
Fixes #64 

Currently the user is not able to specify the units of the plane-wave
energy cutoffs when using the `aiida-pseudo family cutoffs set` command.
This means that the user is limited to only specifying the units in
electronvolt.

Here we add the `-u/--unit` option to the `aiida-pseudo family cutoffs set`
command to allow to user to specify the units of the cutoff values
provided in the CUTOFFS JSON file.