### PR TITLE
CLI: refactor download code from automated install commands

### DIFF
--- a/aiida_pseudo/cli/utils.py
+++ b/aiida_pseudo/cli/utils.py
@@ -52,7 +52,8 @@ def create_family_from_archive(cls, label, filepath_archive, fmt=None, pseudo_ty
     with tempfile.TemporaryDirectory() as dirpath:
 
         try:
-            shutil.unpack_archive(filepath_archive, dirpath, format=fmt)
+            # In Python 3.6 the ``unpack_archive`` method does not yet support ``pathlib.Path`` objects.
+            shutil.unpack_archive(str(filepath_archive), dirpath, format=fmt)
         except shutil.ReadError as exception:
             raise OSError(f'failed to unpack the archive `{filepath_archive}`: {exception}') from exception
 

--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -333,7 +333,8 @@ class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
 
         with tempfile.TemporaryDirectory() as dirpath:
             try:
-                shutil.unpack_archive(filepath_metadata, dirpath, format=fmt)
+                # In Python 3.6 the ``unpack_archive`` method does not yet support ``pathlib.Path`` objects.
+                shutil.unpack_archive(str(filepath_metadata), dirpath, format=fmt)
             except shutil.ReadError as exception:
                 raise OSError(
                     f'failed to unpack the metadata archive `{filepath_metadata}`: {exception}'

--- a/aiida_pseudo/groups/family/sssp.py
+++ b/aiida_pseudo/groups/family/sssp.py
@@ -22,6 +22,7 @@ class SsspFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
     _pseudo_types = (UpfData,)
 
     label_template = 'SSSP/{version}/{functional}/{protocol}'
+    filename_template = 'SSSP_{version}_{functional}_{protocol}'
     default_configuration = SsspConfiguration('1.1', 'PBE', 'efficiency')
     valid_configurations = (
         SsspConfiguration('1.0', 'PBE', 'efficiency'),
@@ -47,6 +48,18 @@ class SsspFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
         return cls.label_template.format(
             version=configuration.version, functional=configuration.functional, protocol=configuration.protocol
         )
+
+    @classmethod
+    def format_configuration_filename(cls, configuration: SsspConfiguration, extension: str) -> str:
+        """Format the filename for a file of a particular SSSP configuration as it is available from MC Archive.
+
+        :param configuration: the SSSP configuration.
+        :param extension: the filename extension without the leading dot.
+        :return: filename
+        """
+        return cls.filename_template.format(
+            version=configuration.version, functional=configuration.functional, protocol=configuration.protocol
+        ) + f'.{extension}'
 
     def __init__(self, label=None, **kwargs):
         """Construct a new instance, validating that the label matches the required format."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,7 +102,8 @@ def get_pseudo_potential_data(filepath_pseudos):
         """
         if entry_point is None:
             cls = DataFactory('pseudo')
-            pseudo = cls(io.BytesIO(b'content'), f'{element}.pseudo')
+            content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="4.0"\n/></UPF>\n'
+            pseudo = cls(io.BytesIO(content.encode('utf-8')), f'{element}.pseudo')
             pseudo.element = element
         else:
             cls = DataFactory(f'pseudo.{entry_point}')


### PR DESCRIPTION
This serves two purposes: it makes it easier to reuse the download code
outside of the CLI and secondly, it enables the mocking of this part of
the code, which is a heavy operation. Without this, unit testing of this
command would be prohibitively expensive as it would need to download
all files for every test.