### PR TITLE
CLI: do not override existing stringencies in `family cutoffs set`

### DIFF
--- a/aiida_pseudo/cli/family.py
+++ b/aiida_pseudo/cli/family.py
@@ -86,8 +86,17 @@ def cmd_family_cutoffs_set(family, cutoffs, stringency, unit):  # noqa: D301
     except ValueError as exception:
         raise click.BadParameter(f'`{cutoffs.name}` contains invalid JSON: {exception}', param_hint='CUTOFFS')
 
+    # This limitation can be removed once ``set_cutoffs`` allows to set additive stringencies and each stringency can
+    # define its own unit.
+    current_unit = family.get_cutoffs_unit()
+    if unit != current_unit:
+        raise click.BadParameter(f'`{unit}` does not match the unit of the family `{current_unit}`', param_hint='UNIT')
+
     try:
-        family.set_cutoffs({stringency: data}, unit=unit)
+        # This code can also be simplified once ``set_cutoffs`` allows to set individual stringencies additively.
+        current_cutoffs = family._get_cutoffs()  # pylint: disable=protected-access
+        current_cutoffs[stringency] = data
+        family.set_cutoffs(current_cutoffs, default_stringency=family.get_default_stringency(), unit=unit)
     except ValueError as exception:
         raise click.BadParameter(f'`{cutoffs.name}` contains invalid cutoffs: {exception}', param_hint='CUTOFFS')
 


### PR DESCRIPTION
Fixes #66 

The command's interface only allows to specify a single stringency at a
time, however, it would use the `set_cutoffs` method internally, which
would override any existing stringencies. This bug is addressed by first
retrieving existing stringencies before adding the new one to it and
setting the ensemble as the new stringencies.

There is an additional limitation that needs to be taken into account,
however. Since the current design only allows for a single energy unit
to be used at a time for all stringencies, when adding a new stringency,
the same unit has to be used. If, in the future, `set_cutoffs` starts to
support setting individual stringencies additively and the family
supports multiple units for the different stringencies, then all of this
logic can be simplified significantly and the limitations removed.