### PR TITLE
`RecommendedCutoffMixin`: set only one stringency with `set_cutoffs`

### DIFF
--- a/aiida_pseudo/cli/family.py
+++ b/aiida_pseudo/cli/family.py
@@ -58,7 +58,7 @@ def cmd_family_cutoffs():
 @options.UNIT()
 @decorators.with_dbenv()
 def cmd_family_cutoffs_set(family, cutoffs, stringency, unit):  # noqa: D301
-    """Set the recommended cutoffs for a pseudo potential family.
+    """Set the recommended cutoffs for a pseudo potential family and a specified stringency.
 
     The cutoffs should be provided as a JSON file through the argument `CUTOFFS` which should have the structure:
 
@@ -86,17 +86,8 @@ def cmd_family_cutoffs_set(family, cutoffs, stringency, unit):  # noqa: D301
     except ValueError as exception:
         raise click.BadParameter(f'`{cutoffs.name}` contains invalid JSON: {exception}', param_hint='CUTOFFS')
 
-    # This limitation can be removed once ``set_cutoffs`` allows to set additive stringencies and each stringency can
-    # define its own unit.
-    current_unit = family.get_cutoffs_unit()
-    if unit != current_unit:
-        raise click.BadParameter(f'`{unit}` does not match the unit of the family `{current_unit}`', param_hint='UNIT')
-
     try:
-        # This code can also be simplified once ``set_cutoffs`` allows to set individual stringencies additively.
-        current_cutoffs = family._get_cutoffs()  # pylint: disable=protected-access
-        current_cutoffs[stringency] = data
-        family.set_cutoffs(current_cutoffs, default_stringency=family.get_default_stringency(), unit=unit)
+        family.set_cutoffs(data, stringency, unit=unit)
     except ValueError as exception:
         raise click.BadParameter(f'`{cutoffs.name}` contains invalid cutoffs: {exception}', param_hint='CUTOFFS')
 

--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -198,7 +198,7 @@ def cmd_install_sssp(version, functional, protocol, traceback):
             cutoffs[element] = {'cutoff_wfc': values['cutoff_wfc'], 'cutoff_rho': values['cutoff_rho']}
 
         family.description = description
-        family.set_cutoffs({'normal': cutoffs}, unit='Ry')
+        family.set_cutoffs(cutoffs, 'normal', unit='Ry')
 
         echo.echo_success(f'installed `{label}` containing {family.count()} pseudo potentials')
 
@@ -305,6 +305,8 @@ def cmd_install_pseudo_dojo(version, functional, relativistic, protocol, pseudo_
                 echo.echo_warning(msg)
 
         family.description = description
-        family.set_cutoffs(cutoffs, default_stringency=default_stringency, unit='Eh')
+        for stringency, cutoff_values in cutoffs.items():
+            family.set_cutoffs(cutoff_values, stringency, unit='Eh')
+        family.set_default_stringency(default_stringency)
 
         echo.echo_success(f'installed `{label}` containing {family.count()} pseudo potentials')

--- a/aiida_pseudo/groups/mixins/cutoffs.py
+++ b/aiida_pseudo/groups/mixins/cutoffs.py
@@ -98,7 +98,7 @@ class RecommendedCutoffMixin:
         """
         return self.get_extra(self._key_cutoffs, {})
 
-    def _get_cutoffs_unit_dict(self) -> str:
+    def _get_cutoffs_unit_dict(self) -> dict:
         """Return the cutoffs units for each of the stringencies.
 
         :return: the cutoffs units extra or an empty dictionary if it has not yet been set.
@@ -119,14 +119,14 @@ class RecommendedCutoffMixin:
     def set_default_stringency(self, default_stringency: str) -> None:
         """Set the default stringency for the recommended cutoffs.
 
-        :param default_stringency: the default stringency to be used when ``get_recommended_cutoffs`` is called. If is
+        :param default_stringency: the default stringency to be used when ``get_recommended_cutoffs`` is called. It is
             possible to not specify this if and only if the cutoffs only contain a single stringency set. That one will
             then automatically be set as default.
         :raises ValueError: if the provided default stringency is not in the tuple of available cutoff stringencies for
             the pseudo family.
         """
         if default_stringency not in self.get_cutoff_stringencies():
-            raise ValueError('provided default stringency not in tuple of available cutoff stringencies.')
+            raise ValueError(f'provided default stringency not in tuple of available cutoff stringencies: {self.get_cutoff_stringencies}.')
 
         self.set_extra(self._key_default_stringency, default_stringency)
 
@@ -140,7 +140,7 @@ class RecommendedCutoffMixin:
     def set_cutoffs(self, cutoffs: dict, stringency: str, unit: str = None) -> None:
         """Set the recommended cutoffs for the pseudos in this family and a specified stringency.
 
-        .. note: If there is only one stringency defined for the pseudo family, this method will automatically set this
+        .. note: If, after the cutoffs have been set, there is only one stringency defined for the pseudo family, this method will automatically set this
             as the default. Use the ``set_default_stringency`` method to change the default when setting multiple
             stringencies.
 
@@ -193,8 +193,8 @@ class RecommendedCutoffMixin:
             raise ValueError(f'stringency `{stringency}` is not defined for this family.') from exception
 
     def get_cutoffs_unit(self, stringency: str = None) -> str:
-        """Return the cutoffs unit.
-
+        """Return the cutoffs unit for the specified or family default stringency.
+:param stringency: optional stringency for which to retrieve the unit. If not specified, the default stringency of the family is uses.
         :return: the string representation of the unit of the cutoffs.
         """
         stringency = stringency or self.get_default_stringency()

--- a/tests/cli/test_family.py
+++ b/tests/cli/test_family.py
@@ -13,7 +13,7 @@ from aiida_pseudo.groups.family import PseudoPotentialFamily, CutoffsFamily
 
 
 @pytest.fixture
-def generate_cutoffs_dict(tmp_path):
+def generate_cutoffs_dict():
     """Return a dictionary of cutoffs for a given family."""
 
     def _generate_cutoffs_dict(family, stringencies=('normal',)):
@@ -31,7 +31,7 @@ def generate_cutoffs_dict(tmp_path):
 
 
 @pytest.fixture
-def generate_cutoffs(tmp_path):
+def generate_cutoffs():
     """Return a dictionary of cutoffs for a given family."""
 
     def _generate_cutoffs(family):

--- a/tests/cli/test_family.py
+++ b/tests/cli/test_family.py
@@ -89,10 +89,8 @@ def test_family_cutoffs_set_unit(run_cli_command, get_pseudo_family, generate_cu
     stringency = 'normal'
     cutoffs = generate_cutoffs(family)
 
-    # Currently, the CLI checks that the unit set matches the one already set on the family, because only a single
-    # unit can be used at a time. This limitation will soon be removed though, at which point, this family should have
-    # eV as a unit, such that the test of the CLI call to set it to hartree actually tests that the unit is changed.
-    family.set_cutoffs(cutoffs, stringency, 'hartree')
+    # We explicitly set the unit to the default (eV) in case this is changed in the future to hartree.
+    family.set_cutoffs(cutoffs, stringency, 'eV')
 
     filepath = tmp_path / 'cutoffs.json'
     filepath.write_text(json.dumps(cutoffs))

--- a/tests/cli/test_family.py
+++ b/tests/cli/test_family.py
@@ -12,40 +12,6 @@ from aiida_pseudo.cli.family import cmd_family_cutoffs_set, cmd_family_show
 from aiida_pseudo.groups.family import PseudoPotentialFamily, CutoffsFamily
 
 
-@pytest.fixture
-def generate_cutoffs_dict():
-    """Return a dictionary of cutoffs for a given family."""
-
-    def _generate_cutoffs_dict(family, stringencies=('normal',)):
-        """Return a dictionary of cutoffs for a given family."""
-        cutoffs_dict = {}
-
-        for stringency in stringencies:
-            cutoffs_dict[stringency] = {}
-            for element in family.elements:
-                cutoffs_dict[stringency][element] = {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0}
-
-        return cutoffs_dict
-
-    return _generate_cutoffs_dict
-
-
-@pytest.fixture
-def generate_cutoffs():
-    """Return a dictionary of cutoffs for a given family."""
-
-    def _generate_cutoffs(family):
-        """Return a dictionary of cutoffs for a given family."""
-        cutoffs = {}
-
-        for element in family.elements:
-            cutoffs[element] = {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0}
-
-        return cutoffs
-
-    return _generate_cutoffs
-
-
 @pytest.mark.usefixtures('clear_db')
 def test_family_cutoffs_set(run_cli_command, get_pseudo_family, generate_cutoffs_dict, tmp_path):
     """Test the `aiida-pseudo family cutoffs set` command."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,33 @@ def get_pseudo_potential_data(filepath_pseudos):
 
 
 @pytest.fixture
+def generate_cutoffs():
+    """Return a dictionary of cutoffs for all elements in a given family."""
+
+    def _generate_cutoffs(family):
+        """Return a dictionary of cutoffs for a given family."""
+        return {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in family.elements}
+
+    return _generate_cutoffs
+
+
+@pytest.fixture
+def generate_cutoffs_dict(generate_cutoffs):
+    """Return a dictionary of cutoffs for a given family with specified stringencies."""
+
+    def _generate_cutoffs_dict(family, stringencies=('normal',)):
+        """Return a dictionary of cutoffs for a given family."""
+        cutoffs_dict = {}
+
+        for stringency in stringencies:
+            cutoffs_dict[stringency] = generate_cutoffs(family)
+
+        return cutoffs_dict
+
+    return _generate_cutoffs_dict
+
+
+@pytest.fixture
 def get_pseudo_family(tmpdir, filepath_pseudos):
     """Return a factory for a ``PseudoPotentialFamily`` instance."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,15 +125,18 @@ def get_pseudo_family(tmpdir, filepath_pseudos):
         cls=PseudoPotentialFamily,
         pseudo_type=PseudoPotentialData,
         elements=None,
-        cutoffs=None,
+        cutoffs_dict=None,
         unit=None,
         default_stringency=None
     ) -> PseudoPotentialFamily:
         """Return an instance of `PseudoPotentialFamily` or subclass containing the given elements.
 
         :param elements: optional list of elements to include instead of all the available ones
-        :params cutoffs: optional dictionary of cutoffs to specify. Needs to respect the format expected by the method
-            `aiida_pseudo.groups.mixins.cutoffs.RecommendedCutoffMixin.set_cutoffs`.
+        :params cutoffs_dict: optional dictionary of cutoffs to specify. Format: multiple sets of cutoffs can be
+            specified where the key represents the stringency, e.g. ``low`` or ``normal``. For each stringency, a
+            dictionary should be defined that for each element symbols for which the family contains a pseudopotential,
+            two values are specified, ``cutoff_wfc`` and ``cutoff_rho``, containing a float value with the recommended
+            cutoff to be used for the wave functions and charge density, respectively..
         :param unit: string definition of a unit of energy as recognized by the ``UnitRegistry`` of the ``pint`` lib.
         :param default_stringency: string with the default stringency name, if not specified, the first one specified in
             the ``cutoffs`` argument will be used if specified.
@@ -156,9 +159,11 @@ def get_pseudo_family(tmpdir, filepath_pseudos):
 
         family = cls.create_from_folder(str(tmpdir), label, pseudo_type=pseudo_type)
 
-        if cutoffs is not None and isinstance(family, CutoffsFamily):
-            default_stringency = default_stringency or list(cutoffs.keys())[0]
-            family.set_cutoffs(cutoffs, default_stringency, unit)
+        if cutoffs_dict is not None and isinstance(family, CutoffsFamily):
+            default_stringency = default_stringency or list(cutoffs_dict.keys())[0]
+            for stringency, cutoff_values in cutoffs_dict.items():
+                family.set_cutoffs(cutoff_values, stringency, unit)
+            family.set_default_stringency(default_stringency)
 
         return family
 

--- a/tests/groups/mixins/test_cutoffs.py
+++ b/tests/groups/mixins/test_cutoffs.py
@@ -9,10 +9,10 @@ from aiida_pseudo.groups.family import CutoffsFamily
 
 
 @pytest.fixture
-def get_cutoffs():
+def get_cutoffs_dict():
     """Return a cutoffs dictionary."""
 
-    def _get_cutoffs(family, stringencies=('default',)):
+    def _get_cutoffs_dict(family, stringencies=('default',)):
         cutoffs = {}
 
         for element in family.elements:
@@ -23,17 +23,18 @@ def get_cutoffs():
 
         return {stringency: cutoffs for stringency in stringencies}
 
-    return _get_cutoffs
+    return _get_cutoffs_dict
 
 
 @pytest.mark.usefixtures('clear_db')
-def test_get_cutoffs_private(get_pseudo_family, get_cutoffs):
-    """Test the ``CutoffsFamily._get_cutoffs`` method."""
+def test_get_cutoffs_private(get_pseudo_family, get_cutoffs_dict):
+    """Test the ``CutoffsFamily._get_cutoffs_dict`` method."""
     family = get_pseudo_family(cls=CutoffsFamily)
-    assert family._get_cutoffs() == {}  # pylint: disable=protected-access
+    assert family._get_cutoffs_dict() == {}  # pylint: disable=protected-access
 
-    family.set_cutoffs(get_cutoffs(family), 'default')
-    assert family._get_cutoffs() == get_cutoffs(family)  # pylint: disable=protected-access
+    for stringency, cutoffs in get_cutoffs_dict(family).items():
+        family.set_cutoffs(cutoffs, stringency)
+    assert family._get_cutoffs_dict() == get_cutoffs_dict(family)  # pylint: disable=protected-access
 
 
 @pytest.mark.usefixtures('clear_db')
@@ -50,16 +51,16 @@ def test_validate_cutoffs_unit():
 
 
 @pytest.mark.usefixtures('clear_db')
-def test_validate_stringency(get_pseudo_family, get_cutoffs):
+def test_validate_stringency(get_pseudo_family, get_cutoffs_dict):
     """Test the ``CutoffsFamily.validate_stringency`` method."""
     family = get_pseudo_family(cls=CutoffsFamily)
 
     with pytest.raises(ValueError, match=r'stringency `.*` is not defined for this family.'):
         family.validate_stringency('default')
 
-    cutoffs = get_cutoffs(family)
-    stringency = list(cutoffs.keys())[0]
-    family.set_cutoffs(cutoffs, stringency)
+    cutoffs_dict = get_cutoffs_dict(family)
+    stringency = list(cutoffs_dict.keys())[0]
+    family.set_cutoffs(cutoffs_dict[stringency], stringency)
 
     with pytest.raises(ValueError, match=r'stringency `.*` is not defined for this family.'):
         family.validate_stringency(stringency + 'non-existing')
@@ -68,29 +69,29 @@ def test_validate_stringency(get_pseudo_family, get_cutoffs):
 
 
 @pytest.mark.usefixtures('clear_db')
-def test_get_default_stringency(get_pseudo_family, get_cutoffs):
+def test_get_default_stringency(get_pseudo_family, get_cutoffs_dict):
     """Test the ``CutoffsFamily.get_default_stringency`` method."""
     family = get_pseudo_family(cls=CutoffsFamily)
 
     with pytest.raises(ValueError, match='no default stringency has been defined.'):
         family.get_default_stringency()
 
-    cutoffs = get_cutoffs(family)
-    stringency = list(cutoffs.keys())[0]
-    family.set_cutoffs(cutoffs, stringency)
+    cutoffs_dict = get_cutoffs_dict(family)
+    stringency = list(cutoffs_dict.keys())[0]
+    family.set_cutoffs(cutoffs_dict[stringency], stringency)
 
     assert family.get_default_stringency() == stringency
 
 
 @pytest.mark.usefixtures('clear_db')
-def test_get_cutoff_stringencies(get_pseudo_family, get_cutoffs):
+def test_get_cutoff_stringencies(get_pseudo_family, get_cutoffs_dict):
     """Test the ``CutoffsFamily.get_cutoff_stringencies`` method."""
     family = get_pseudo_family(cls=CutoffsFamily)
     assert family.get_cutoff_stringencies() == ()
 
     stringencies = ('low', 'normal', 'high')
-    cutoffs = get_cutoffs(family, stringencies)
-    family.set_cutoffs(cutoffs, stringencies[0])
+    for stringency, cutoffs in get_cutoffs_dict(family, stringencies).items():
+        family.set_cutoffs(cutoffs, stringency)
 
     assert sorted(family.get_cutoff_stringencies()) == sorted(stringencies)
 
@@ -100,35 +101,37 @@ def test_set_cutoffs(get_pseudo_family):
     """Test the ``CutoffsFamily.set_cutoffs`` method."""
     elements = ['Ar', 'He']
     family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
-    cutoffs = {'default': {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}}
-    family.set_cutoffs(cutoffs, 'default')
+    cutoffs = {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}
+    stringency = 'default'
+    family.set_cutoffs(cutoffs, stringency)
 
-    assert family.get_cutoffs() == cutoffs['default']
+    assert family.get_cutoffs() == cutoffs
+    assert family.get_cutoffs(stringency) == cutoffs
 
     with pytest.raises(ValueError, match=r'cutoffs defined for unsupported elements: .*'):
         cutoffs_invalid = copy.deepcopy(cutoffs)
-        cutoffs_invalid['default']['C'] = {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0}
-        family.set_cutoffs(cutoffs_invalid, 'default')
+        cutoffs_invalid['C'] = {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0}
+        family.set_cutoffs(cutoffs_invalid, stringency)
 
     with pytest.raises(ValueError, match=r'cutoffs not defined for all family elements: .*'):
         cutoffs_invalid = copy.deepcopy(cutoffs)
-        cutoffs_invalid['default'].pop('He')
-        family.set_cutoffs(cutoffs_invalid, 'default')
+        cutoffs_invalid.pop('He')
+        family.set_cutoffs(cutoffs_invalid, stringency)
 
-    with pytest.raises(ValueError, match=r'invalid cutoff keys for stringency `default` and element .*: .*'):
+    with pytest.raises(ValueError, match=r'invalid cutoff keys for element .*: .*'):
         cutoffs_invalid = copy.deepcopy(cutoffs)
-        cutoffs_invalid['default']['He'] = {'cutoff_wfc': 1.0}
-        family.set_cutoffs(cutoffs_invalid, 'default')
+        cutoffs_invalid['He'] = {'cutoff_wfc': 1.0}
+        family.set_cutoffs(cutoffs_invalid, stringency)
 
-    with pytest.raises(ValueError, match=r'invalid cutoff keys for stringency `default` and element .*: .*'):
+    with pytest.raises(ValueError, match=r'invalid cutoff keys for element .*: .*'):
         cutoffs_invalid = copy.deepcopy(cutoffs)
-        cutoffs_invalid['default']['He'] = {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0, 'cutoff_extra': 3.0}
-        family.set_cutoffs(cutoffs_invalid, 'default')
+        cutoffs_invalid['He'] = {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0, 'cutoff_extra': 3.0}
+        family.set_cutoffs(cutoffs_invalid, stringency)
 
-    with pytest.raises(ValueError, match=r'invalid cutoff values for stringency `default` and element .*: .*'):
+    with pytest.raises(ValueError, match=r'invalid cutoff values for element .*: .*'):
         cutoffs_invalid = copy.deepcopy(cutoffs)
-        cutoffs_invalid['default']['He'] = {'cutoff_wfc': 1.0, 'cutoff_rho': 'string'}
-        family.set_cutoffs(cutoffs_invalid, 'default')
+        cutoffs_invalid['He'] = {'cutoff_wfc': 1.0, 'cutoff_rho': 'string'}
+        family.set_cutoffs(cutoffs_invalid, stringency)
 
 
 @pytest.mark.usefixtures('clear_db')
@@ -136,29 +139,26 @@ def test_set_cutoffs_unit_default(get_pseudo_family):
     """Test the ``CutoffsFamily.set_cutoffs`` sets a default unit if not specified."""
     elements = ['Ar']
     family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
-    values = {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}
-    cutoffs = {'default': values}
+    cutoffs = {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}
+    stringency = 'default'
 
-    family.set_cutoffs(cutoffs)
+    family.set_cutoffs(cutoffs, stringency)
     assert family.get_cutoffs_unit() == CutoffsFamily.DEFAULT_UNIT
 
 
 @pytest.mark.usefixtures('clear_db')
 def test_set_cutoffs_auto_default(get_pseudo_family):
-    """Test the ``CutoffsFamily.set_cutoffs`` method when not specifying explicit default.
+    """Test that the ``CutoffsFamily.set_cutoffs`` method specifies the correct default stringency.
 
-    If the cutoffs specified only contain a single set, the `default_stringency` is determined automatically.
+    If family only has one stringency specified, the `set_cutoffs` method automatically sets this as the default.
     """
     elements = ['Ar']
     family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
-    values = {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}
-    cutoffs = {'default': values}
+    cutoffs = {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}
+    stringency = 'default'
 
-    with pytest.raises(ValueError, match='specify a default stringency when specifying multiple cutoff sets.'):
-        family.set_cutoffs({'low': values, 'hi': values})
-
-    family.set_cutoffs(cutoffs)
-    assert family.get_cutoffs() == cutoffs['default']
+    family.set_cutoffs(cutoffs, stringency)
+    assert family.get_cutoffs() == cutoffs
     assert family.get_default_stringency() == 'default'
 
 
@@ -167,24 +167,30 @@ def test_get_cutoffs(get_pseudo_family):
     """Test the ``CutoffsFamily.get_cutoffs`` method."""
     elements = ['Ar', 'He']
     family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
-    cutoffs = {'default': {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}}
+    cutoffs = {element: {'cutoff_wfc': 1.0, 'cutoff_rho': 2.0} for element in elements}
+    stringency = 'default'
 
     with pytest.raises(ValueError, match='no default stringency has been defined.'):
         family.get_cutoffs()
 
-    family.set_cutoffs(cutoffs, 'default')
+    family.set_cutoffs(cutoffs, stringency)
 
     with pytest.raises(ValueError, match=r'stringency `.*` is not defined for this family.'):
         family.get_cutoffs('non-existing')
 
-    assert family.get_cutoffs() == cutoffs['default']
+    assert family.get_cutoffs() == cutoffs
+
+    low_cutoffs = {element: {'cutoff_wfc': 0.5, 'cutoff_rho': 1.0} for element in elements}
+    family.set_cutoffs(low_cutoffs, 'low')
+
+    assert family.get_cutoffs('low') == low_cutoffs
 
 
 @pytest.mark.usefixtures('clear_db')
 def test_get_recommended_cutoffs(get_pseudo_family, generate_structure):
     """Test the ``CutoffsFamily.get_recommended_cutoffs`` method."""
     elements = ['Ar', 'He']
-    cutoffs = {
+    cutoffs_dict = {
         'default': {
             'Ar': {
                 'cutoff_wfc': 1.0,
@@ -200,7 +206,7 @@ def test_get_recommended_cutoffs(get_pseudo_family, generate_structure):
         label='SSSP/1.0/PBE/efficiency',
         cls=CutoffsFamily,
         elements=elements,
-        cutoffs=cutoffs,
+        cutoffs_dict=cutoffs_dict,
         default_stringency='default'
     )
     structure = generate_structure(elements=elements)
@@ -217,18 +223,18 @@ def test_get_recommended_cutoffs(get_pseudo_family, generate_structure):
     with pytest.raises(TypeError):
         family.get_recommended_cutoffs(elements=None, structure='Ar')
 
-    expected = cutoffs['default']['Ar']
+    expected = cutoffs_dict['default']['Ar']
     assert family.get_recommended_cutoffs(elements='Ar') == (expected['cutoff_wfc'], expected['cutoff_rho'])
     assert family.get_recommended_cutoffs(elements=('Ar',)) == (expected['cutoff_wfc'], expected['cutoff_rho'])
 
-    expected = cutoffs['default']['He']
+    expected = cutoffs_dict['default']['He']
     assert family.get_recommended_cutoffs(elements=('Ar', 'He')) == (expected['cutoff_wfc'], expected['cutoff_rho'])
 
-    expected = cutoffs['default']['He']
+    expected = cutoffs_dict['default']['He']
     assert family.get_recommended_cutoffs(structure=structure) == (expected['cutoff_wfc'], expected['cutoff_rho'])
 
     # Try structure with multiple kinds with the same element
-    expected = cutoffs['default']['He']
+    expected = cutoffs_dict['default']['He']
     structure = generate_structure(elements=['He1', 'He2'])
     assert family.get_recommended_cutoffs(structure=structure) == (expected['cutoff_wfc'], expected['cutoff_rho'])
 
@@ -238,7 +244,7 @@ def test_get_recommended_cutoffs_unit(get_pseudo_family):
     """Test the ``CutoffsFamily.get_recommended_cutoffs`` method with the ``unit`` argument."""
     elements = ['Ar', 'He']
     unit = 'Eh'
-    cutoffs = {
+    cutoffs_dict = {
         'default': {
             'Ar': {
                 'cutoff_wfc': 1.0,
@@ -254,12 +260,12 @@ def test_get_recommended_cutoffs_unit(get_pseudo_family):
         label='SSSP/1.0/PBE/efficiency',
         cls=CutoffsFamily,
         elements=elements,
-        cutoffs=cutoffs,
+        cutoffs_dict=cutoffs_dict,
         default_stringency='default',
         unit=unit
     )
 
-    cutoffs_ar = cutoffs['default']['Ar']
+    cutoffs_ar = cutoffs_dict['default']['Ar']
 
     expected = (cutoffs_ar['cutoff_wfc'], cutoffs_ar['cutoff_rho'])
     assert family.get_recommended_cutoffs(elements='Ar') == expected
@@ -269,13 +275,34 @@ def test_get_recommended_cutoffs_unit(get_pseudo_family):
 
 
 @pytest.mark.usefixtures('clear_db')
-def test_get_cutoffs_unit(get_pseudo_family, get_cutoffs):
+def test_get_cutoffs_unit(get_pseudo_family):
     """Test the ``CutoffsFamily.get_cutoffs_unit`` method."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    elements = ['Ar', 'He']
+    cutoffs_dict = {
+        'default': {
+            'Ar': {
+                'cutoff_wfc': 1.0,
+                'cutoff_rho': 2.0
+            },
+            'He': {
+                'cutoff_wfc': 3.0,
+                'cutoff_rho': 8.0
+            },
+        }
+    }
+    family = get_pseudo_family(
+        label='SSSP/1.0/PBE/efficiency',
+        cls=CutoffsFamily,
+        elements=elements,
+        cutoffs_dict=cutoffs_dict,
+        default_stringency='default',
+    )
     assert family.get_cutoffs_unit() == 'eV'
+    cutoffs = family.get_cutoffs()
+    stringency = family.get_default_stringency()
 
-    family.set_cutoffs(get_cutoffs(family), unit='Ry')
+    family.set_cutoffs(cutoffs, stringency, unit='Ry')
     assert family.get_cutoffs_unit() == 'Ry'
 
-    family.set_cutoffs(get_cutoffs(family), unit='Eh')
+    family.set_cutoffs(cutoffs, stringency, unit='Eh')
     assert family.get_cutoffs_unit() == 'Eh'


### PR DESCRIPTION
Fixes #68 

Currently the behaviour of the `set_cutoffs` and `get_cutoffs` methods of the
`RecommendedCutoffMixin` class is different. The first sets the cutoffs for all
stringencies along with a default stringency, the second only retrieves the
cutoffs for a specified stringency. This can be somewhat confusing for the
user, and means that the user cannot easily set the cutoffs for a single
stringency.

Here we change the `set_cutoffs` method so it only sets the recommended
cutoffs for a single stringency, which has to be specified as an input
argument. The stringency is automatically set to be the default in case
it is the only stringency specified, and a `set_default_stringency`
method is added to the user can still change the default stringency at
any time after setting multiple stringencies.

We also allow the user to specify units for each stringency, extending
the value corresponding to the `_key_cutoffs_unit` in the extras to a
dictionary that specifies the units for each stringency, similar to the
cutoffs.