### PR TITLE
Dependencies: remove temporary upper limit for `sqlalchemy`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -41,8 +41,7 @@
         "click-completion~=0.5",
         "pint~=0.16.1",
         "psycopg2-binary<2.9",
-        "requests~=2.20",
-        "sqlalchemy<1.4"
+        "requests~=2.20"
     ],
     "extras_require": {
         "pre-commit": [


### PR DESCRIPTION
This reverts `383ab247c40ada60c22ce3673cbbc3efccd21f98`. The upper limit
is no longer necessary as the incompatibility of `sqlalchemy-utils` with
`sqlalchemy==1.4` has been solved downstream.