### PR TITLE
`RecommendedCutoffMixin`: Add support for `aiida-pseudo>=0.4.0` families

### DIFF
--- a/aiida_pseudo/groups/mixins/cutoffs.py
+++ b/aiida_pseudo/groups/mixins/cutoffs.py
@@ -257,8 +257,10 @@ class RecommendedCutoffMixin:
         except KeyError as exception:
             # Workaround to deal with pseudo families installed in v0.5.0 - Set default unit in case it is not in extras
             if stringency in self.get_cutoff_stringencies():
-                self.set_cutoffs(self.get_cutoffs(stringency), stringency, unit=self.DEFAULT_UNIT)
-                return self.DEFAULT_UNIT
+                cutoffs_unit_dict = self._get_cutoffs_unit_dict()
+                cutoffs_unit_dict[stringency] = 'eV'
+                self.set_extra(self._key_cutoffs_unit, cutoffs_unit_dict)
+                return 'eV'
             # End of workaround
             raise ValueError(f'stringency `{stringency}` is not defined for this family.') from exception
 

--- a/aiida_pseudo/groups/mixins/cutoffs.py
+++ b/aiida_pseudo/groups/mixins/cutoffs.py
@@ -211,7 +211,7 @@ class RecommendedCutoffMixin:
         cutoffs_dict.pop(stringency)
 
         cutoffs_unit_dict = self._get_cutoffs_unit_dict()
-        cutoffs_unit_dict.pop(stringency)
+        cutoffs_unit_dict.pop(stringency, None)  # `None` is added to support pseudo families installed with v0.5.0
 
         self.set_extra(self._key_cutoffs, cutoffs_dict)
         self.set_extra(self._key_cutoffs_unit, cutoffs_unit_dict)
@@ -255,6 +255,11 @@ class RecommendedCutoffMixin:
         try:
             return self._get_cutoffs_unit_dict()[stringency]
         except KeyError as exception:
+            # Workaround to deal with pseudo families installed in v0.5.0 - Set default unit in case it is not in extras
+            if stringency in self.get_cutoff_stringencies():
+                self.set_cutoffs(self.get_cutoffs(stringency), stringency, unit=self.DEFAULT_UNIT)
+                return self.DEFAULT_UNIT
+            # End of workaround
             raise ValueError(f'stringency `{stringency}` is not defined for this family.') from exception
 
     def get_recommended_cutoffs(self, *, elements=None, structure=None, stringency=None, unit=None):


### PR DESCRIPTION
Currently, pseudo families installed with `aiida-pseudo>=0.4.0` will
fail to work with the new API features in two ways, both related to the
addition of units for the recommended cutoffs:

* `delete_cutoffs` expects the units to be stored in the
`'_cutoffs_unit'` extras dictionary. Simply adding `None` as a default
to return in the `.pop()` call fixes this issue.
* `get_cutoffs_unit` will return a `KeyError` since the previously
configured stringencies did not include units. Here we can add an `if`
clause that check if the requested stringency _does_ have its cutoffs
set. Since the default unit was and is `eV`, we set this as the new unit
for the stringency. From then on the pseudo family will be "fixed".

Note: families installed with `aiida-pseudo<=0.3.0` will still cause
problems since the units for the recommended cutoffs were set to
eV in v0.4.0.