### PR TITLE
Rename `CutoffsFamily` to `CutoffsPseudoPotentialFamily`

### DIFF
--- a/aiida_pseudo/groups/family/cutoffs.py
+++ b/aiida_pseudo/groups/family/cutoffs.py
@@ -3,10 +3,10 @@
 from ..mixins import RecommendedCutoffMixin
 from .pseudo import PseudoPotentialFamily
 
-__all__ = ('CutoffsFamily',)
+__all__ = ('CutoffsPseudoPotentialFamily',)
 
 
-class CutoffsFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
+class CutoffsPseudoPotentialFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
     """Subclass of ``PseudoPotentialFamily`` designed to represent a family with recommended cutoffs.
 
     This is mostly used for testing the functionality around the ``RecommendedCutoffMixin``.

--- a/setup.json
+++ b/setup.json
@@ -29,7 +29,7 @@
         ],
         "aiida.groups": [
             "pseudo.family = aiida_pseudo.groups.family.pseudo:PseudoPotentialFamily",
-            "pseudo.family.cutoffs = aiida_pseudo.groups.family.cutoffs:CutoffsFamily",
+            "pseudo.family.cutoffs = aiida_pseudo.groups.family.cutoffs:CutoffsPseudoPotentialFamily",
             "pseudo.family.pseudo_dojo = aiida_pseudo.groups.family.pseudo_dojo:PseudoDojoFamily",
             "pseudo.family.sssp = aiida_pseudo.groups.family.sssp:SsspFamily"
         ]

--- a/tests/cli/test_family.py
+++ b/tests/cli/test_family.py
@@ -9,13 +9,13 @@ import pytest
 from aiida.orm import Group
 
 from aiida_pseudo.cli.family import cmd_family_cutoffs_set, cmd_family_show
-from aiida_pseudo.groups.family import PseudoPotentialFamily, CutoffsFamily
+from aiida_pseudo.groups.family import PseudoPotentialFamily, CutoffsPseudoPotentialFamily
 
 
 @pytest.mark.usefixtures('clear_db')
 def test_family_cutoffs_set(run_cli_command, get_pseudo_family, generate_cutoffs_dict, tmp_path):
     """Test the `aiida-pseudo family cutoffs set` command."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
     stringencies = ('low', 'normal', 'high')
     cutoffs_dict = generate_cutoffs_dict(family, stringencies=stringencies)
 
@@ -51,7 +51,7 @@ def test_family_cutoffs_set(run_cli_command, get_pseudo_family, generate_cutoffs
 @pytest.mark.usefixtures('clear_db')
 def test_family_cutoffs_set_unit(run_cli_command, get_pseudo_family, generate_cutoffs, tmp_path):
     """Test the `aiida-pseudo family cutoffs set` command with the ``--unit`` flag."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
     stringency = 'normal'
     cutoffs = generate_cutoffs(family)
 
@@ -86,7 +86,7 @@ def test_family_show(clear_db, run_cli_command, get_pseudo_family):
 
 def test_family_show_recommended_cutoffs(clear_db, run_cli_command, get_pseudo_family, generate_cutoffs_dict):
     """Test the `aiida-pseudo show` command for a family with recommended cutoffs."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
     stringencies = ('normal', 'high')
     cutoffs_dict = generate_cutoffs_dict(family, stringencies=stringencies)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import pytest
 from aiida.plugins import DataFactory
 
 from aiida_pseudo.data.pseudo import PseudoPotentialData
-from aiida_pseudo.groups.family import PseudoPotentialFamily, CutoffsFamily
+from aiida_pseudo.groups.family import PseudoPotentialFamily, CutoffsPseudoPotentialFamily
 
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
 
@@ -193,7 +193,7 @@ def get_pseudo_family(tmpdir, filepath_pseudos):
 
         family = cls.create_from_folder(str(tmpdir), label, pseudo_type=pseudo_type)
 
-        if cutoffs_dict is not None and isinstance(family, CutoffsFamily):
+        if cutoffs_dict is not None and isinstance(family, CutoffsPseudoPotentialFamily):
             default_stringency = default_stringency or list(cutoffs_dict.keys())[0]
             for stringency, cutoff_values in cutoffs_dict.items():
                 family.set_cutoffs(cutoff_values, stringency, unit)

--- a/tests/groups/mixins/test_cutoffs.py
+++ b/tests/groups/mixins/test_cutoffs.py
@@ -5,13 +5,13 @@ import copy
 
 import pytest
 
-from aiida_pseudo.groups.family import CutoffsFamily
+from aiida_pseudo.groups.family import CutoffsPseudoPotentialFamily
 
 
 @pytest.mark.usefixtures('clear_db')
 def test_get_cutoffs_dict(get_pseudo_family, generate_cutoffs_dict):
-    """Test the ``CutoffsFamily._get_cutoffs_dict`` method."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    """Test the ``CutoffsPseudoPotentialFamily._get_cutoffs_dict`` method."""
+    family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
     assert family._get_cutoffs_dict() == {}  # pylint: disable=protected-access
 
     for stringency, cutoffs in generate_cutoffs_dict(family).items():
@@ -21,35 +21,35 @@ def test_get_cutoffs_dict(get_pseudo_family, generate_cutoffs_dict):
 
 @pytest.mark.usefixtures('clear_db')
 def test_get_cutoffs_unit_dict(get_pseudo_family, generate_cutoffs_dict):
-    """Test the ``CutoffsFamily._get_cutoffs_unit_dict`` method."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    """Test the ``CutoffsPseudoPotentialFamily._get_cutoffs_unit_dict`` method."""
+    family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
     assert family._get_cutoffs_unit_dict() == {}  # pylint: disable=protected-access
 
     default_units_dict = {}
     for stringency, cutoffs in generate_cutoffs_dict(family).items():
         family.set_cutoffs(cutoffs, stringency)
-        default_units_dict[stringency] = CutoffsFamily.DEFAULT_UNIT
+        default_units_dict[stringency] = CutoffsPseudoPotentialFamily.DEFAULT_UNIT
 
     assert family._get_cutoffs_unit_dict() == default_units_dict  # pylint: disable=protected-access
 
 
 @pytest.mark.usefixtures('clear_db')
 def test_validate_cutoffs_unit():
-    """Test the ``CutoffsFamily.validate_cutoffs_unit`` method."""
+    """Test the ``CutoffsPseudoPotentialFamily.validate_cutoffs_unit`` method."""
     with pytest.raises(TypeError):
-        CutoffsFamily.validate_cutoffs_unit(10)
+        CutoffsPseudoPotentialFamily.validate_cutoffs_unit(10)
 
     with pytest.raises(ValueError, match=r'`invalid` is not a valid unit.'):
-        CutoffsFamily.validate_cutoffs_unit('invalid')
+        CutoffsPseudoPotentialFamily.validate_cutoffs_unit('invalid')
 
     with pytest.raises(ValueError, match=r'`watt` is not a valid energy unit.'):
-        CutoffsFamily.validate_cutoffs_unit('watt')
+        CutoffsPseudoPotentialFamily.validate_cutoffs_unit('watt')
 
 
 @pytest.mark.usefixtures('clear_db')
 def test_validate_stringency(get_pseudo_family, generate_cutoffs):
-    """Test the ``CutoffsFamily.validate_stringency`` method."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    """Test the ``CutoffsPseudoPotentialFamily.validate_stringency`` method."""
+    family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
 
     with pytest.raises(ValueError, match=r'stringency `.*` is not defined for this family.'):
         family.validate_stringency('default')
@@ -66,8 +66,8 @@ def test_validate_stringency(get_pseudo_family, generate_cutoffs):
 
 @pytest.mark.usefixtures('clear_db')
 def test_get_default_stringency(get_pseudo_family, generate_cutoffs):
-    """Test the ``CutoffsFamily.get_default_stringency`` method."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    """Test the ``CutoffsPseudoPotentialFamily.get_default_stringency`` method."""
+    family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
 
     with pytest.raises(ValueError, match='no default stringency has been defined.'):
         family.get_default_stringency()
@@ -81,8 +81,8 @@ def test_get_default_stringency(get_pseudo_family, generate_cutoffs):
 
 @pytest.mark.usefixtures('clear_db')
 def test_set_default_stringency(get_pseudo_family, generate_cutoffs_dict):
-    """Test the ``CutoffsFamily.set_default_stringency`` method."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    """Test the ``CutoffsPseudoPotentialFamily.set_default_stringency`` method."""
+    family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
     assert family.get_cutoff_stringencies() == ()
 
     stringencies = ('low', 'normal')
@@ -100,8 +100,8 @@ def test_set_default_stringency(get_pseudo_family, generate_cutoffs_dict):
 
 @pytest.mark.usefixtures('clear_db')
 def test_get_cutoff_stringencies(get_pseudo_family, generate_cutoffs_dict):
-    """Test the ``CutoffsFamily.get_cutoff_stringencies`` method."""
-    family = get_pseudo_family(cls=CutoffsFamily)
+    """Test the ``CutoffsPseudoPotentialFamily.get_cutoff_stringencies`` method."""
+    family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
     assert family.get_cutoff_stringencies() == ()
 
     stringencies = ('low', 'normal', 'high')
@@ -113,9 +113,9 @@ def test_get_cutoff_stringencies(get_pseudo_family, generate_cutoffs_dict):
 
 @pytest.mark.usefixtures('clear_db')
 def test_set_cutoffs(get_pseudo_family, generate_cutoffs):
-    """Test the ``CutoffsFamily.set_cutoffs`` method."""
+    """Test the ``CutoffsPseudoPotentialFamily.set_cutoffs`` method."""
     elements = ['Ar', 'He']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsPseudoPotentialFamily, elements=elements)
     cutoffs = generate_cutoffs(family)
     stringency = 'default'
 
@@ -151,21 +151,21 @@ def test_set_cutoffs(get_pseudo_family, generate_cutoffs):
 
 @pytest.mark.usefixtures('clear_db')
 def test_set_cutoffs_unit_default(get_pseudo_family, generate_cutoffs):
-    """Test the ``CutoffsFamily.set_cutoffs`` sets a default unit if not specified."""
+    """Test the ``CutoffsPseudoPotentialFamily.set_cutoffs`` sets a default unit if not specified."""
     elements = ['Ar']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsPseudoPotentialFamily, elements=elements)
     cutoffs = generate_cutoffs(family)
     stringency = 'default'
 
     family.set_cutoffs(cutoffs, stringency)
-    assert family.get_cutoffs_unit() == CutoffsFamily.DEFAULT_UNIT
+    assert family.get_cutoffs_unit() == CutoffsPseudoPotentialFamily.DEFAULT_UNIT
 
 
 @pytest.mark.usefixtures('clear_db')
 def test_set_cutoffs_multiple_units(get_pseudo_family, generate_cutoffs):
-    """Test the ``CutoffsFamily.set_cutoffs`` correctly sets separate units for different stringencies."""
+    """Test ``CutoffsPseudoPotentialFamily.set_cutoffs`` correctly sets separate units for different stringencies."""
     elements = ['Ar']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsPseudoPotentialFamily, elements=elements)
     cutoffs = generate_cutoffs(family)
 
     cutoffs_unit_dict = {}
@@ -188,12 +188,12 @@ def test_set_cutoffs_multiple_units(get_pseudo_family, generate_cutoffs):
 
 @pytest.mark.usefixtures('clear_db')
 def test_set_cutoffs_auto_default(get_pseudo_family, generate_cutoffs):
-    """Test that the ``CutoffsFamily.set_cutoffs`` method specifies the correct default stringency.
+    """Test that the ``CutoffsPseudoPotentialFamily.set_cutoffs`` method specifies the correct default stringency.
 
     If family only has one stringency specified, the `set_cutoffs` method automatically sets this as the default.
     """
     elements = ['Ar']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsPseudoPotentialFamily, elements=elements)
     cutoffs = generate_cutoffs(family)
     stringency = 'default'
 
@@ -204,9 +204,9 @@ def test_set_cutoffs_auto_default(get_pseudo_family, generate_cutoffs):
 
 @pytest.mark.usefixtures('clear_db')
 def test_get_cutoffs(get_pseudo_family, generate_cutoffs):
-    """Test the ``CutoffsFamily.get_cutoffs`` method."""
+    """Test the ``CutoffsPseudoPotentialFamily.get_cutoffs`` method."""
     elements = ['Ar', 'He']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsPseudoPotentialFamily, elements=elements)
     cutoffs = generate_cutoffs(family)
     stringency = 'default'
 
@@ -228,9 +228,9 @@ def test_get_cutoffs(get_pseudo_family, generate_cutoffs):
 
 @pytest.mark.usefixtures('clear_db')
 def test_get_recommended_cutoffs(get_pseudo_family, generate_structure, generate_cutoffs):
-    """Test the ``CutoffsFamily.get_recommended_cutoffs`` method."""
+    """Test the ``CutoffsPseudoPotentialFamily.get_recommended_cutoffs`` method."""
     elements = ['Ar', 'He']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsPseudoPotentialFamily, elements=elements)
     cutoffs = generate_cutoffs(family)
     stringency = 'default'
     family.set_cutoffs(cutoffs, stringency)
@@ -267,9 +267,9 @@ def test_get_recommended_cutoffs(get_pseudo_family, generate_structure, generate
 
 @pytest.mark.usefixtures('clear_db')
 def test_get_recommended_cutoffs_unit(get_pseudo_family, generate_cutoffs):
-    """Test the ``CutoffsFamily.get_recommended_cutoffs`` method with the ``unit`` argument."""
+    """Test the ``CutoffsPseudoPotentialFamily.get_recommended_cutoffs`` method with the ``unit`` argument."""
     elements = ['Ar', 'He']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsPseudoPotentialFamily, elements=elements)
     cutoffs = generate_cutoffs(family)
     stringency = 'default'
     unit = 'Eh'
@@ -286,9 +286,9 @@ def test_get_recommended_cutoffs_unit(get_pseudo_family, generate_cutoffs):
 
 @pytest.mark.usefixtures('clear_db')
 def test_get_cutoffs_unit(get_pseudo_family, generate_cutoffs):
-    """Test the ``CutoffsFamily.get_cutoffs_unit`` method."""
+    """Test the ``CutoffsPseudoPotentialFamily.get_cutoffs_unit`` method."""
     elements = ['Ar', 'He']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsPseudoPotentialFamily, elements=elements)
     cutoffs = generate_cutoffs(family)
     stringency = 'default'
     family.set_cutoffs(cutoffs, stringency)
@@ -306,9 +306,9 @@ def test_get_cutoffs_unit(get_pseudo_family, generate_cutoffs):
 
 @pytest.mark.usefixtures('clear_db')
 def test_delete_cutoffs(get_pseudo_family, generate_cutoffs_dict):
-    """Test the ``CutoffsFamily.delete_cutoffs`` method."""
+    """Test the ``CutoffsPseudoPotentialFamily.delete_cutoffs`` method."""
     elements = ['Ar', 'He']
-    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsFamily, elements=elements)
+    family = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=CutoffsPseudoPotentialFamily, elements=elements)
 
     stringencies = ('low', 'normal', 'high')
     for stringency, cutoffs in generate_cutoffs_dict(family, stringencies).items():


### PR DESCRIPTION
The `CutoffsFamily` was introduced in order to properly test the
`RecommendedCutoffsMixin`. It was even given an entry point but this was
just a requirement for the tests to work and it was never intended to
actually be used in production. However, there now seems an actual
usecase for this class as a substitute for the `SsspFamily` and
`PseudoDojoFamily` who also have the mixin and allow recommended cutoffs
to be defined but they come with strict rules and only official sets of
pseudopotentials are supported.

If one wants to create a custom pseudopotential family but still want to
use the recommended cutoff functionality, the `PseudoPotentialFamily`
base class doesn't suffice but the `CutoffsFamily` does. Now that we
actually consider the class to be used for production, a more aptly
named class name is required to properly reflect its intended usage.