### PR TITLE
CI: use `postgresql` instead of `postgresql-10`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         -   name: Install system dependencies
             run: |
                 sudo apt update
-                sudo apt install postgresql-10
+                sudo apt install postgresql
 
         -   name: Install python dependencies
             run: |


### PR DESCRIPTION
The CI uses `ubuntu-latest` as the image for the OS which recently got
updated to Ubuntu 20.04. This distribution no longer has `postgresql-10`
which was being installed. We replace this with `postgresql` which will
simply install whatever version of PostgreSQL is the default.