### PR TITLE
`PseudoPotentialData`: allow `str` or `Path` for `source` argument

### DIFF
--- a/aiida_pseudo/data/pseudo/jthxml.py
+++ b/aiida_pseudo/data/pseudo/jthxml.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Module for data plugin to represent a pseudo potential in JTH XML format."""
+import pathlib
 import re
-from typing import BinaryIO
+import typing
 
 from .pseudo import PseudoPotentialData
 
@@ -10,7 +11,7 @@ __all__ = ('JthXmlData',)
 REGEX_ELEMENT = re.compile(r"""\s*symbol\s*=\s*['"]\s*(?P<element>[a-zA-Z]{1,2})\s*['"].*""")
 
 
-def parse_element(stream: BinaryIO):
+def parse_element(stream: typing.BinaryIO):
     """Parse the content of the JTH XML file to determine the element.
 
     :param stream: a filelike object with the binary content of the file.
@@ -30,14 +31,26 @@ def parse_element(stream: BinaryIO):
 class JthXmlData(PseudoPotentialData):
     """Data plugin to represent a pseudo potential in JTH XML format."""
 
-    def set_file(self, stream: BinaryIO, filename: str = None, **kwargs):  # pylint: disable=arguments-differ
-        """Set the file content.
+    def set_file(self, source: typing.Union[str, pathlib.Path, typing.BinaryIO], filename: str = None, **kwargs):  # pylint: disable=arguments-differ
+        """Set the file content and parse other optional attributes from the content.
 
-        :param stream: a filelike object with the binary content of the file.
+        .. note:: this method will first analyse the type of the ``source`` and if it is a filepath will convert it
+            to a binary stream of the content located at that filepath, which is then passed on to the superclass. This
+            needs to be done first, because it will properly set the file and filename attributes that are expected by
+            other methods. Straight after the superclass call, the source seeker needs to be reset to zero if it needs
+            to be read again, because the superclass most likely will have read the stream to the end. Finally it is
+            important that the ``prepare_source`` is called here before the superclass invocation, because this way the
+            conversion from filepath to byte stream will be performed only once. Otherwise, each subclass would perform
+            the conversion over and over again.
+
+        :param source: the source pseudopotential content, either a binary stream, or a ``str`` or ``Path`` to the path
+            of the file on disk, which can be relative or absolute.
         :param filename: optional explicit filename to give to the file stored in the repository.
+        :raises TypeError: if the source is not a ``str``, ``pathlib.Path`` instance or binary stream.
+        :raises FileNotFoundError: if the source is a filepath but does not exist.
         :raises ValueError: if the element symbol is invalid.
         """
-        stream.seek(0)
-        self.element = parse_element(stream)
-        stream.seek(0)
-        super().set_file(stream, filename, **kwargs)
+        source = self.prepare_source(source)
+        super().set_file(source, filename, **kwargs)
+        source.seek(0)
+        self.element = parse_element(source)

--- a/aiida_pseudo/data/pseudo/pseudo.py
+++ b/aiida_pseudo/data/pseudo/pseudo.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Base class for data types representing pseudo potentials."""
+import io
+import pathlib
 import typing
 
 from aiida import orm
@@ -18,23 +20,28 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
     _key_md5 = 'md5'
 
     @classmethod
-    def get_or_create(cls, stream: typing.BinaryIO, filename: str = None):
+    def get_or_create(cls, source: typing.Union[str, pathlib.Path, typing.BinaryIO], filename: str = None):
         """Get pseudopotenial data node from database with matching md5 checksum or create a new one if not existent.
 
-        :param stream: a filelike object with the binary content of the file.
+        :param source: the source pseudopotential content, either a binary stream, or a ``str`` or ``Path`` to the path
+            of the file on disk, which can be relative or absolute.
         :param filename: optional explicit filename to give to the file stored in the repository.
         :return: instance of ``PseudoPotentialData``, stored if taken from database, unstored otherwise.
+        :raises TypeError: if the source is not a ``str``, ``pathlib.Path`` instance or binary stream.
+        :raises FileNotFoundError: if the source is a filepath but does not exist.
         """
+        source = cls.prepare_source(source)
+
         query = orm.QueryBuilder()
-        query.append(cls, subclassing=False, filters={f'attributes.{cls._key_md5}': md5_from_filelike(stream)})
+        query.append(cls, subclassing=False, filters={f'attributes.{cls._key_md5}': md5_from_filelike(source)})
 
         existing = query.first()
 
         if existing:
             pseudo = existing[0]
         else:
-            stream.seek(0)
-            pseudo = cls(stream, filename)
+            source.seek(0)
+            pseudo = cls(source, filename)
 
         return pseudo
 
@@ -47,6 +54,40 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
         from aiida.plugins.entry_point import get_entry_point_from_class
         _, entry_point = get_entry_point_from_class(cls.__module__, cls.__name__)
         return entry_point.name
+
+    @staticmethod
+    def is_readable_byte_stream(stream) -> bool:
+        """Return whether an object appears to be a readable filelike object in binary mode or stream of bytes.
+
+        :param stream: the object to analyse.
+        :returns: True if ``stream`` appears to be a readable filelike object in binary mode, False otherwise.
+        """
+        return (
+            isinstance(stream, io.BytesIO) or
+            (hasattr(stream, 'read') and hasattr(stream, 'mode') and 'b' in stream.mode)
+        )
+
+    @classmethod
+    def prepare_source(cls, source: typing.Union[str, pathlib.Path, typing.BinaryIO]) -> typing.BinaryIO:
+        """Validate the ``source`` representing a file on disk or a byte stream.
+
+        .. note:: if the ``source`` is a valid file on disk, its content is read and returned as a stream of bytes.
+
+        :raises TypeError: if the source is not a ``str``, ``pathlib.Path`` instance or binary stream.
+        :raises FileNotFoundError: if the source is a filepath but does not exist.
+        """
+        if not isinstance(source, (str, pathlib.Path)) and not cls.is_readable_byte_stream(source):
+            raise TypeError(
+                f'`source` should be a `str` or `pathlib.Path` filepath on disk or a stream of bytes, got: {source}'
+            )
+
+        if isinstance(source, (str, pathlib.Path)):
+            filename = pathlib.Path(source).name
+            with open(source, 'rb') as handle:
+                source = io.BytesIO(handle.read())
+                source.name = filename
+
+        return source
 
     @classmethod
     def validate_element(cls, element: str):
@@ -69,15 +110,28 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
             if md5 != md5_file:
                 raise ValueError(f'md5 does not match that of stored file: {md5} != {md5_file}')
 
-    def set_file(self, stream: typing.BinaryIO, filename: str = None, **kwargs):
+    def set_file(self, source: typing.Union[str, pathlib.Path, typing.BinaryIO], filename: str = None, **kwargs):
         """Set the file content.
 
-        :param stream: a filelike object with the binary content of the file.
+        .. note:: this method will first analyse the type of the ``source`` and if it is a filepath will convert it
+            to a binary stream of the content located at that filepath, which is then passed on to the superclass. This
+            needs to be done first, because it will properly set the file and filename attributes that are expected by
+            other methods. Straight after the superclass call, the source seeker needs to be reset to zero if it needs
+            to be read again, because the superclass most likely will have read the stream to the end. Finally it is
+            important that the ``prepare_source`` is called here before the superclass invocation, because this way the
+            conversion from filepath to byte stream will be performed only once. Otherwise, each subclass would perform
+            the conversion over and over again.
+
+        :param source: the source pseudopotential content, either a binary stream, or a ``str`` or ``Path`` to the path
+            of the file on disk, which can be relative or absolute.
         :param filename: optional explicit filename to give to the file stored in the repository.
+        :raises TypeError: if the source is not a ``str``, ``pathlib.Path`` instance or binary stream.
+        :raises FileNotFoundError: if the source is a filepath but does not exist.
         """
-        super().set_file(stream, filename, **kwargs)
-        stream.seek(0)
-        self.md5 = md5_from_filelike(stream)
+        source = self.prepare_source(source)
+        super().set_file(source, filename, **kwargs)
+        source.seek(0)
+        self.md5 = md5_from_filelike(source)
 
     def store(self, **kwargs):
         """Store the node verifying first that all required attributes are set.
@@ -97,7 +151,7 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
         return super().store(**kwargs)
 
     @property
-    def element(self) -> typing.Union[str, None]:
+    def element(self) -> typing.Optional[int]:
         """Return the element symbol.
 
         :return: the symbol of the element following the IUPAC naming standard or None if not defined.
@@ -115,7 +169,7 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
         self.set_attribute(self._key_element, value)
 
     @property
-    def md5(self) -> typing.Union[str, None]:
+    def md5(self) -> typing.Optional[int]:
         """Return the md5.
 
         :return: the md5 of the stored file.

--- a/aiida_pseudo/data/pseudo/psf.py
+++ b/aiida_pseudo/data/pseudo/psf.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Module for data plugin to represent a pseudo potential in PSF format."""
+import pathlib
 import re
-from typing import BinaryIO
+import typing
 
 from .pseudo import PseudoPotentialData
 
@@ -10,7 +11,7 @@ __all__ = ('PsfData',)
 REGEX_ELEMENT = re.compile(r"""\s*(?P<element>[a-zA-Z]{1}[a-z]?)\s+.*""")
 
 
-def parse_element(stream: BinaryIO):
+def parse_element(stream: typing.BinaryIO):
     """Parse the content of the PSF file to determine the element.
 
     :param stream: a filelike object with the binary content of the file.
@@ -29,14 +30,26 @@ def parse_element(stream: BinaryIO):
 class PsfData(PseudoPotentialData):
     """Data plugin to represent a pseudo potential in PSF format."""
 
-    def set_file(self, stream: BinaryIO, filename: str = None, **kwargs):  # pylint: disable=arguments-differ
-        """Set the file content.
+    def set_file(self, source: typing.Union[str, pathlib.Path, typing.BinaryIO], filename: str = None, **kwargs):  # pylint: disable=arguments-differ
+        """Set the file content and parse other optional attributes from the content.
 
-        :param stream: a filelike object with the binary content of the file.
+        .. note:: this method will first analyse the type of the ``source`` and if it is a filepath will convert it
+            to a binary stream of the content located at that filepath, which is then passed on to the superclass. This
+            needs to be done first, because it will properly set the file and filename attributes that are expected by
+            other methods. Straight after the superclass call, the source seeker needs to be reset to zero if it needs
+            to be read again, because the superclass most likely will have read the stream to the end. Finally it is
+            important that the ``prepare_source`` is called here before the superclass invocation, because this way the
+            conversion from filepath to byte stream will be performed only once. Otherwise, each subclass would perform
+            the conversion over and over again.
+
+        :param source: the source pseudopotential content, either a binary stream, or a ``str`` or ``Path`` to the path
+            of the file on disk, which can be relative or absolute.
         :param filename: optional explicit filename to give to the file stored in the repository.
+        :raises TypeError: if the source is not a ``str``, ``pathlib.Path`` instance or binary stream.
+        :raises FileNotFoundError: if the source is a filepath but does not exist.
         :raises ValueError: if the element symbol is invalid.
         """
-        stream.seek(0)
-        self.element = parse_element(stream)
-        stream.seek(0)
-        super().set_file(stream, filename, **kwargs)
+        source = self.prepare_source(source)
+        super().set_file(source, filename, **kwargs)
+        source.seek(0)
+        self.element = parse_element(source)

--- a/aiida_pseudo/data/pseudo/psml.py
+++ b/aiida_pseudo/data/pseudo/psml.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Module for data plugin to represent a pseudo potential in PSML format."""
+import pathlib
 import re
-from typing import BinaryIO
+import typing
 
 from .pseudo import PseudoPotentialData
 
@@ -10,7 +11,7 @@ __all__ = ('PsmlData',)
 REGEX_ELEMENT = re.compile(r"""\s*(?P<element>[a-zA-Z]{1}[a-z]?)\s+.*""")
 
 
-def parse_element(stream: BinaryIO):
+def parse_element(stream: typing.BinaryIO):
     """Parse the content of the PSML file to determine the element.
 
     :param stream: a filelike object with the binary content of the file.
@@ -30,14 +31,26 @@ def parse_element(stream: BinaryIO):
 class PsmlData(PseudoPotentialData):
     """Data plugin to represent a pseudo potential in PSML format."""
 
-    def set_file(self, stream: BinaryIO, filename: str = None, **kwargs):  # pylint: disable=arguments-differ
-        """Set the file content.
+    def set_file(self, source: typing.Union[str, pathlib.Path, typing.BinaryIO], filename: str = None, **kwargs):  # pylint: disable=arguments-differ
+        """Set the file content and parse other optional attributes from the content.
 
-        :param stream: a filelike object with the binary content of the file.
+        .. note:: this method will first analyse the type of the ``source`` and if it is a filepath will convert it
+            to a binary stream of the content located at that filepath, which is then passed on to the superclass. This
+            needs to be done first, because it will properly set the file and filename attributes that are expected by
+            other methods. Straight after the superclass call, the source seeker needs to be reset to zero if it needs
+            to be read again, because the superclass most likely will have read the stream to the end. Finally it is
+            important that the ``prepare_source`` is called here before the superclass invocation, because this way the
+            conversion from filepath to byte stream will be performed only once. Otherwise, each subclass would perform
+            the conversion over and over again.
+
+        :param source: the source pseudopotential content, either a binary stream, or a ``str`` or ``Path`` to the path
+            of the file on disk, which can be relative or absolute.
         :param filename: optional explicit filename to give to the file stored in the repository.
+        :raises TypeError: if the source is not a ``str``, ``pathlib.Path`` instance or binary stream.
+        :raises FileNotFoundError: if the source is a filepath but does not exist.
         :raises ValueError: if the element symbol is invalid.
         """
-        stream.seek(0)
-        self.element = parse_element(stream)
-        stream.seek(0)
-        super().set_file(stream, filename, **kwargs)
+        source = self.prepare_source(source)
+        super().set_file(source, filename, **kwargs)
+        source.seek(0)
+        self.element = parse_element(source)

--- a/aiida_pseudo/data/pseudo/psp8.py
+++ b/aiida_pseudo/data/pseudo/psp8.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Module for data plugin to represent a pseudo potential in Psp8 format."""
-from typing import BinaryIO
+import pathlib
+import typing
+
 from aiida.common.constants import elements
 
 from .pseudo import PseudoPotentialData
@@ -8,7 +10,7 @@ from .pseudo import PseudoPotentialData
 __all__ = ('Psp8Data',)
 
 
-def parse_element(stream: BinaryIO):
+def parse_element(stream: typing.BinaryIO):
     """Parse the content of the Psp8 file to determine the element.
 
     :param stream: a filelike object with the binary content of the file.
@@ -38,14 +40,26 @@ def parse_element(stream: BinaryIO):
 class Psp8Data(PseudoPotentialData):
     """Data plugin to represent a pseudo potential in Psp8 (Abinit) format."""
 
-    def set_file(self, stream: BinaryIO, filename: str = None, **kwargs):  # pylint: disable=arguments-differ
-        """Set the file content.
+    def set_file(self, source: typing.Union[str, pathlib.Path, typing.BinaryIO], filename: str = None, **kwargs):  # pylint: disable=arguments-differ
+        """Set the file content and parse other optional attributes from the content.
 
-        :param stream: a filelike object with the binary content of the file.
+        .. note:: this method will first analyse the type of the ``source`` and if it is a filepath will convert it
+            to a binary stream of the content located at that filepath, which is then passed on to the superclass. This
+            needs to be done first, because it will properly set the file and filename attributes that are expected by
+            other methods. Straight after the superclass call, the source seeker needs to be reset to zero if it needs
+            to be read again, because the superclass most likely will have read the stream to the end. Finally it is
+            important that the ``prepare_source`` is called here before the superclass invocation, because this way the
+            conversion from filepath to byte stream will be performed only once. Otherwise, each subclass would perform
+            the conversion over and over again.
+
+        :param source: the source pseudopotential content, either a binary stream, or a ``str`` or ``Path`` to the path
+            of the file on disk, which can be relative or absolute.
         :param filename: optional explicit filename to give to the file stored in the repository.
+        :raises TypeError: if the source is not a ``str``, ``pathlib.Path`` instance or binary stream.
+        :raises FileNotFoundError: if the source is a filepath but does not exist.
         :raises ValueError: if the element symbol is invalid.
         """
-        stream.seek(0)
-        self.element = parse_element(stream)
-        stream.seek(0)
-        super().set_file(stream, filename, **kwargs)
+        source = self.prepare_source(source)
+        super().set_file(source, filename, **kwargs)
+        source.seek(0)
+        self.element = parse_element(source)

--- a/aiida_pseudo/data/pseudo/upf.py
+++ b/aiida_pseudo/data/pseudo/upf.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Module for data plugin to represent a pseudo potential in UPF format."""
+import pathlib
 import re
-from typing import BinaryIO, Union
+import typing
 
 from .pseudo import PseudoPotentialData
 
@@ -62,24 +63,34 @@ class UpfData(PseudoPotentialData):
 
     _key_z_valence = 'z_valence'
 
-    def set_file(self, stream: BinaryIO, filename: str = None, **kwargs):  # pylint: disable=arguments-differ
-        """Set the file content.
+    def set_file(self, source: typing.Union[str, pathlib.Path, typing.BinaryIO], filename: str = None, **kwargs):  # pylint: disable=arguments-differ
+        """Set the file content and parse other optional attributes from the content.
 
-        :param stream: a filelike object with the binary content of the file.
+        .. note:: this method will first analyse the type of the ``source`` and if it is a filepath will convert it
+            to a binary stream of the content located at that filepath, which is then passed on to the superclass. This
+            needs to be done first, because it will properly set the file and filename attributes that are expected by
+            other methods. Straight after the superclass call, the source seeker needs to be reset to zero if it needs
+            to be read again, because the superclass most likely will have read the stream to the end. Finally it is
+            important that the ``prepare_source`` is called here before the superclass invocation, because this way the
+            conversion from filepath to byte stream will be performed only once. Otherwise, each subclass would perform
+            the conversion over and over again.
+
+        :param source: the source pseudopotential content, either a binary stream, or a ``str`` or ``Path`` to the path
+            of the file on disk, which can be relative or absolute.
         :param filename: optional explicit filename to give to the file stored in the repository.
+        :raises TypeError: if the source is not a ``str``, ``pathlib.Path`` instance or binary stream.
+        :raises FileNotFoundError: if the source is a filepath but does not exist.
         :raises ValueError: if the element symbol is invalid.
         """
-        stream.seek(0)
-
-        content = stream.read().decode('utf-8')
+        source = self.prepare_source(source)
+        super().set_file(source, filename, **kwargs)
+        source.seek(0)
+        content = source.read().decode('utf-8')
         self.element = parse_element(content)
         self.z_valence = parse_z_valence(content)
 
-        stream.seek(0)
-        super().set_file(stream, filename, **kwargs)
-
     @property
-    def z_valence(self) -> Union[int, None]:
+    def z_valence(self) -> typing.Optional[int]:
         """Return the Z valence.
 
         :return: the Z valence.

--- a/tests/data/pseudo/test_jthxml.py
+++ b/tests/data/pseudo/test_jthxml.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
 """Tests for the :py:`~aiida_pseudo.data.pseudo.jthxml` module."""
+import io
 import os
+import pathlib
 
 import pytest
 
@@ -8,7 +11,28 @@ from aiida.common.exceptions import ModificationNotAllowed
 from aiida_pseudo.data.pseudo import JthXmlData
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.fixture
+def source(request, filepath_pseudos):
+    """Return a pseudopotential, eiter as ``str``, ``Path`` or ``io.BytesIO``."""
+    filepath_pseudo = pathlib.Path(filepath_pseudos(entry_point='jthxml')) / 'Ar.jthxml'
+
+    if request.param is str:
+        return str(filepath_pseudo)
+
+    if request.param is pathlib.Path:
+        return filepath_pseudo
+
+    return io.BytesIO(filepath_pseudo.read_bytes())
+
+
+@pytest.mark.parametrize('source', (io.BytesIO, str, pathlib.Path), indirect=True)
+def test_constructor_source_types(source):
+    """Test the constructor accept the various types."""
+    pseudo = JthXmlData(source)
+    assert isinstance(pseudo, JthXmlData)
+    assert not pseudo.is_stored
+
+
 def test_constructor(filepath_pseudos):
     """Test the constructor."""
     for filename in os.listdir(filepath_pseudos('jthxml')):

--- a/tests/data/pseudo/test_psml.py
+++ b/tests/data/pseudo/test_psml.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
 """Tests for the :py:`~aiida_pseudo.data.pseudo.psml` module."""
+import io
 import os
+import pathlib
 
 import pytest
 
@@ -8,7 +11,28 @@ from aiida.common.exceptions import ModificationNotAllowed
 from aiida_pseudo.data.pseudo import PsmlData
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.fixture
+def source(request, filepath_pseudos):
+    """Return a pseudopotential, eiter as ``str``, ``Path`` or ``io.BytesIO``."""
+    filepath_pseudo = pathlib.Path(filepath_pseudos(entry_point='psml')) / 'Ar.psml'
+
+    if request.param is str:
+        return str(filepath_pseudo)
+
+    if request.param is pathlib.Path:
+        return filepath_pseudo
+
+    return io.BytesIO(filepath_pseudo.read_bytes())
+
+
+@pytest.mark.parametrize('source', (io.BytesIO, str, pathlib.Path), indirect=True)
+def test_constructor_source_types(source):
+    """Test the constructor accept the various types."""
+    pseudo = PsmlData(source)
+    assert isinstance(pseudo, PsmlData)
+    assert not pseudo.is_stored
+
+
 def test_constructor(filepath_pseudos):
     """Test the constructor."""
     for filename in os.listdir(filepath_pseudos('psml')):

--- a/tests/data/pseudo/test_upf.py
+++ b/tests/data/pseudo/test_upf.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
 """Tests for the :py:`~aiida_pseudo.data.pseudo.upf` module."""
+import io
 import os
+import pathlib
 
 import pytest
 
@@ -9,7 +12,28 @@ from aiida_pseudo.data.pseudo import UpfData
 from aiida_pseudo.data.pseudo.upf import parse_z_valence
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.fixture
+def source(request, filepath_pseudos):
+    """Return a pseudopotential, eiter as ``str``, ``Path`` or ``io.BytesIO``."""
+    filepath_pseudo = pathlib.Path(filepath_pseudos(entry_point='upf')) / 'Ar.upf'
+
+    if request.param is str:
+        return str(filepath_pseudo)
+
+    if request.param is pathlib.Path:
+        return filepath_pseudo
+
+    return io.BytesIO(filepath_pseudo.read_bytes())
+
+
+@pytest.mark.parametrize('source', (io.BytesIO, str, pathlib.Path), indirect=True)
+def test_constructor_source_types(source):
+    """Test the constructor accept the various types."""
+    pseudo = UpfData(source)
+    assert isinstance(pseudo, UpfData)
+    assert not pseudo.is_stored
+
+
 def test_constructor(filepath_pseudos):
     """Test the constructor."""
     for filename in os.listdir(filepath_pseudos('upf')):

--- a/tests/data/pseudo/test_vps.py
+++ b/tests/data/pseudo/test_vps.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
 """Tests for the :py:`~aiida_pseudo.data.pseudo.vps` module."""
+import io
 import os
+import pathlib
 
 import pytest
 
@@ -9,7 +12,28 @@ from aiida_pseudo.data.pseudo import VpsData
 from aiida_pseudo.data.pseudo.vps import parse_z_valence, parse_xc_type
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.fixture
+def source(request, filepath_pseudos):
+    """Return a pseudopotential, eiter as ``str``, ``Path`` or ``io.BytesIO``."""
+    filepath_pseudo = pathlib.Path(filepath_pseudos(entry_point='vps')) / 'Ar.vps'
+
+    if request.param is str:
+        return str(filepath_pseudo)
+
+    if request.param is pathlib.Path:
+        return filepath_pseudo
+
+    return io.BytesIO(filepath_pseudo.read_bytes())
+
+
+@pytest.mark.parametrize('source', (io.BytesIO, str, pathlib.Path), indirect=True)
+def test_constructor_source_types(source):
+    """Test the constructor accept the various types."""
+    pseudo = VpsData(source)
+    assert isinstance(pseudo, VpsData)
+    assert not pseudo.is_stored
+
+
 def test_constructor(filepath_pseudos):
     """Test the constructor."""
     for filename in os.listdir(filepath_pseudos('vps')):


### PR DESCRIPTION
Fixes #87 

Currently, the source of the pseudopotential passed at construction time
of the `PseudoPotentialData` that represents it had to be a binary
stream. Here we introduce the possibility to allow the caller that pass
a `str` or `Path` object with the absolute path to the file content on
disk that should be wrapped.

There is a potential inefficiency in the implementation after this change.
It is not only the constructor of `SinglefileData`, and therefore our
plugin `PseudoPotentialData` and all its subclasses, that needs to be
able to support the different source types and convert the paths to a
stream if that is what passed, the `set_file` method, which is called by
the constructor needs to apply the same checks and conversions. Here, we
need to therefore make sure that the conversion from filepath to byte
stream is only done once and not in the `set_file` call of every
subclass.

Therefore it is important that the `set_file` method first calls the
`prepare_source` class method, which will only convert to bytestream if
isn't already one, and that should then be passed to the superclass
call. Note that this should be called straight after the `prepare_source`
since the base class will set the actual file and filename attributes
that are methods that may be invoked afterwards will rely on.