### PR TITLE
Dependencies: put upper limit on `psycopg2-binary`

### DIFF
--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -339,7 +339,7 @@ def cmd_install_pseudo_dojo(
             adjusted_cutoffs = {}
             for stringency, str_cutoffs in cutoffs.items():
                 adjusted_cutoffs[stringency] = []
-                max_cutoff_wfc = max([str_cutoffs[element]['cutoff_wfc'] for element in str_cutoffs])
+                max_cutoff_wfc = max([cutoffs['cutoff_wfc'] for cutoffs in str_cutoffs.values()])
                 filler_cutoff_wfc = max_cutoff_wfc * 1.5
                 for element, cutoff in str_cutoffs.items():
                     if cutoff['cutoff_wfc'] <= 0:

--- a/aiida_pseudo/cli/params/arguments.py
+++ b/aiida_pseudo/cli/params/arguments.py
@@ -3,7 +3,7 @@
 from aiida.cmdline.params.arguments import OverridableArgument
 from .types import PseudoPotentialFamilyParam
 
-__all__ = ('PSEUDO_POTENTIAL_FAMILY')
+__all__ = ('PSEUDO_POTENTIAL_FAMILY',)
 
 PSEUDO_POTENTIAL_FAMILY = OverridableArgument(
     'family', type=PseudoPotentialFamilyParam(sub_classes=('aiida.groups:pseudo.family',))

--- a/setup.json
+++ b/setup.json
@@ -40,6 +40,7 @@
         "click~=7.0",
         "click-completion~=0.5",
         "pint~=0.16.1",
+        "psycopg2-binary<2.9",
         "requests~=2.20",
         "sqlalchemy<1.4"
     ],


### PR DESCRIPTION
Fixes #105 

The release `psycopg2-binary==2.9` breaks the unit test manager of
`aiida-core`. This was fixed for in v1.6, however, that version no
longer supports Python 3.6, which falls back on `aiida-core==1.5.2` and
that doesn't apply the upper limit on `psycopg2-binary`, so we are
forced to do it here. This limit can be removed once we drop support for
Python 3.6.

Also fixes two minor things brought up by `pylint`.