### PR TITLE
Replace SSSP link to legacy MC Archive

### DIFF
--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -72,15 +72,10 @@ def cmd_install_family(archive, label, description, archive_format, family_type,
     else:
         # At this point, we can assume that it is not a valid filepath on disk, but rather a URL and the ``archive``
         # variable will contain the result objects from the ``requests`` library. The validation of the URL will already
-        # have been done by the ``PathOrUrl`` parameter type, so the URL is reachable. The content of the URL must be
-        # copied to a local temporary file because `create_family_from_archive` does currently not accept filelike
-        # objects, because in turn the underlying `shutil.unpack_archive` does not. In addition, `unpack_archive` will
-        # attempt to deduce the archive format from the filename extension, so it is important we maintain the original
-        # filename. Of course if this fails, users can specify the archive format explicitly with the corresponding
-        # option. We get the filename by converting the URL to a ``Path`` object and taking the filename, using that as
-        # a suffix for the temporary file that is generated on disk to copy the content to.
-        suffix = pathlib.Path(archive.url).name
-        with tempfile.NamedTemporaryFile(mode='w+b', suffix=suffix) as handle:
+        # have been done by the ``PathOrUrl`` parameter type and will already have retrieved the content. The content of
+        # the URL must be copied to a local temporary file because `create_family_from_archive` does currently not
+        # accept filelike objects, because in turn the underlying `shutil.unpack_archive` does not.
+        with tempfile.NamedTemporaryFile(mode='w+b') as handle:
             handle.write(archive.content)
             handle.flush()
 

--- a/setup.json
+++ b/setup.json
@@ -46,7 +46,7 @@
     "extras_require": {
         "pre-commit": [
             "pre-commit~=2.2",
-            "pylint~=2.6"
+            "pylint~=2.6.0"
         ],
         "tests": [
             "pgtest~=1.3",

--- a/setup.json
+++ b/setup.json
@@ -53,7 +53,8 @@
             "pytest~=5.4"
         ],
         "docs": [
-            "sphinx~=3.2.1",
+            "docutils~=0.17.0",
+            "sphinx~=3.2",
             "sphinx-copybutton~=0.3.0",
             "sphinx-book-theme~=0.0.39",
             "sphinx-autoapi~=1.8.1",

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -157,8 +157,10 @@ def test_install_family_url(run_cli_command):
     """
     label = 'SSSP/1.0/PBE/efficiency'
     description = 'description'
-    filepath_archive = 'https://legacy-archive.materialscloud.org/file/2018.0001/v4/SSSP_1.0_PBE_efficiency.tar.gz'
-    options = ['-D', description, filepath_archive, label, '-P', 'pseudo.upf']
+    configuration = SsspConfiguration('1.0', 'PBE', 'efficiency')
+    filename = SsspFamily.format_configuration_filename(configuration, 'tar.gz', '1.0')
+    filepath_archive = f'https://archive.materialscloud.org/record/file?filename={filename}&record_id=23'
+    options = ['-D', description, '-P', 'pseudo.upf', '-f', 'gztar', filepath_archive, label]
 
     result = run_cli_command(cmd_install_family, options)
     assert f'installed `{label}`' in result.output


### PR DESCRIPTION
Fixes #109 

The `cli.test_install:test_install_family_url` test was using a link to
the legacy version of the Materials Cloud Archive which has now been
taken offline, causing the test to fail. The link is updated to point to
the new server.