### PR TITLE
Use `typing.NamedTuple` for pseudo family configurations

### DIFF
--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -202,7 +202,7 @@ def cmd_install_sssp(version, functional, protocol, download_only, traceback):
     label = SsspFamily.format_configuration_label(configuration)
 
     if configuration not in SsspFamily.valid_configurations:
-        echo.echo_critical(f'{version} {functional} {protocol} is not a valid SSSP configuration')
+        echo.echo_critical(f'{configuration} is not a valid configuration.')
 
     if not download_only and QueryBuilder().append(SsspFamily, filters={'label': label}).first():
         echo.echo_critical(f'{SsspFamily.__name__}<{label}> is already installed')
@@ -250,7 +250,7 @@ def cmd_install_sssp(version, functional, protocol, download_only, traceback):
         family.description = description
         family.set_cutoffs(cutoffs, 'normal', unit='Ry')
 
-        echo.echo_success(f'installed `{label}` containing {family.count()} pseudopotentials')
+        echo.echo_success(f'installed `{label}` containing {family.count()} pseudopotentials.')
 
 
 @cmd_install.command('pseudo-dojo')
@@ -299,17 +299,17 @@ def cmd_install_pseudo_dojo(
     try:
         pseudo_type = pseudo_type_mapping[pseudo_format]
     except KeyError:
-        echo.echo_critical(f'{pseudo_format} is not a valid PseudoDojo pseudopotential format')
+        echo.echo_critical(f'{pseudo_format} is not a valid PseudoDojo pseudopotential format.')
 
     configuration = PseudoDojoConfiguration(version, functional, relativistic, protocol, pseudo_format)
     label = PseudoDojoFamily.format_configuration_label(configuration)
-    description = 'PseudoDojo v{} {} {} {} {} installed with aiida-pseudo v{}'.format(*configuration, __version__)
+    description = f'{configuration} installed with aiida-pseudo v{__version__}'
 
     if configuration not in PseudoDojoFamily.valid_configurations:
-        echo.echo_critical('{} {} {} {} {} is not a valid PseudoDojo configuration'.format(*configuration))
+        echo.echo_critical(f'{configuration} is not a valid configuration')
 
     if not download_only and QueryBuilder().append(PseudoDojoFamily, filters={'label': label}).first():
-        echo.echo_critical(f'{PseudoDojoFamily.__name__}<{label}> is already installed')
+        echo.echo_critical(f'{PseudoDojoFamily.__name__}<{label}> is already installed.')
 
     with tempfile.TemporaryDirectory() as dirpath:
 
@@ -373,4 +373,4 @@ def cmd_install_pseudo_dojo(
             family.set_cutoffs(cutoff_values, stringency, unit='Eh')
         family.set_default_stringency(default_stringency)
 
-        echo.echo_success(f'installed `{label}` containing {family.count()} pseudopotentials')
+        echo.echo_success(f'installed `{label}` containing {family.count()} pseudopotentials.')

--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 """Subclass of `PseudoPotentialFamily` designed to represent a PseudoDojo configuration."""
-import collections
 import json
 import os
 import re
+from typing import NamedTuple, Sequence
 import warnings
 
 from pathlib import Path
-from typing import Sequence
 
 from aiida.common.exceptions import ParsingError
 
@@ -17,9 +16,19 @@ from .pseudo import PseudoPotentialFamily
 
 __all__ = ('PseudoDojoConfiguration', 'PseudoDojoFamily')
 
-PseudoDojoConfiguration = collections.namedtuple(
-    'PseudoDojoConfiguration', ['version', 'functional', 'relativistic', 'protocol', 'pseudo_format']
-)
+
+class PseudoDojoConfiguration(NamedTuple):
+    """Named tuple that represents a PseudoDojo configuration."""
+
+    version: str
+    functional: str
+    relativistic: str
+    protocol: str
+    pseudo_format: str
+
+    def __str__(self):
+        """Represent the configuration as a string."""
+        return f'PseudoDojo v{self.version} {self.functional} {self.relativistic} {self.protocol} {self.pseudo_format}'
 
 
 class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):

--- a/aiida_pseudo/groups/family/sssp.py
+++ b/aiida_pseudo/groups/family/sssp.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Subclass of ``PseudoPotentialFamily`` designed to represent an SSSP configuration."""
-from collections import namedtuple
-from typing import Sequence, Optional
+from typing import NamedTuple, Optional, Sequence
 
 from aiida_pseudo.data.pseudo import UpfData
 from ..mixins import RecommendedCutoffMixin
@@ -9,7 +8,17 @@ from .pseudo import PseudoPotentialFamily
 
 __all__ = ('SsspConfiguration', 'SsspFamily')
 
-SsspConfiguration = namedtuple('SsspConfiguration', ['version', 'functional', 'protocol'])
+
+class SsspConfiguration(NamedTuple):
+    """Named tuple that represents an SSSP configuration."""
+
+    version: str
+    functional: str
+    protocol: str
+
+    def __str__(self):
+        """Represent the configuration as a string."""
+        return f'SSSP v{self.version} {self.functional} {self.protocol}'
 
 
 class SsspFamily(RecommendedCutoffMixin, PseudoPotentialFamily):


### PR DESCRIPTION
The `SsspConfiguration` and `PseudoDojoConfiguration` tuples were
defined using `collections.namedtuple`. These are replaced by using
`typing.NamedTuple` which not only provides type hints for the members
but it allows to define the `__str__` method, which makes it easier to
use the configuration in formatted strings.