### PR TITLE
Tests: do not rely on actual URL to test install family

### DIFF
--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -117,8 +117,8 @@ def test_install_family(run_cli_command, get_pseudo_archive):
     """Test ``aiida-pseudo install family``."""
     label = 'family'
     description = 'description'
-    filepath_archive = next(get_pseudo_archive())
-    options = ['-D', description, filepath_archive, label]
+    filepath = get_pseudo_archive()
+    options = ['-D', description, str(filepath), label]
 
     result = run_cli_command(cmd_install_family, options)
     assert f'installed `{label}`' in result.output
@@ -149,25 +149,38 @@ def test_install_family_folder(run_cli_command, filepath_pseudos):
 
 
 @pytest.mark.usefixtures('clear_db')
-def test_install_family_url(run_cli_command):
+def test_install_family_url(run_cli_command, get_pseudo_archive, monkeypatch):
     """Test ``aiida-pseudo install family`` when installing from a URL.
 
-    When a URL is passed, the parameter converts it into a ``http.client.HTTPResponse``, which is not trivial to mock so
-    instead we use an actual URL, which is slow, but is anyway already tested indirectly in ``test_install_sssp``.
+    Testing this functionality by actually retrieving from a URL has two main downsides: it will be potentially slow
+    by having to download data from the web, but most importantly it is susceptible to random failures if the remote
+    URL is (temporarily) not availabe, or even permanently goes offline, or even the content changes. That is why we
+    monkeypatch the ``PathOrUrl`` instead to simply return the content of an archive that is created on the fly on the
+    local disk. The command expects that the parameter type returns an object that contains the content of the archive
+    under the ``content`` attribute. To mimick this, we construct a namedtuple with a ``content`` attribute on the fly.
     """
+    from aiida_pseudo.cli.params.types import PathOrUrl
+
+    fmt = 'gztar'
     label = 'SSSP/1.0/PBE/efficiency'
     description = 'description'
-    configuration = SsspConfiguration('1.0', 'PBE', 'efficiency')
-    filename = SsspFamily.format_configuration_filename(configuration, 'tar.gz', '1.0')
-    filepath_archive = f'https://archive.materialscloud.org/record/file?filename={filename}&record_id=23'
-    options = ['-D', description, '-P', 'pseudo.upf', '-f', 'gztar', filepath_archive, label]
+    filepath_archive = 'https://archive.materialscloud.org/record/file?filename=fake-url'
+    options = ['-D', description, '-P', 'pseudo.upf', '-f', fmt, filepath_archive, label]
+
+    def convert(*_, **__):
+        from collections import namedtuple
+        Archive = namedtuple('Archive', ['content'])
+        archive = Archive(get_pseudo_archive(fmt=fmt).read_bytes())
+        return archive
+
+    monkeypatch.setattr(PathOrUrl, 'convert', convert)
 
     result = run_cli_command(cmd_install_family, options)
     assert f'installed `{label}`' in result.output
     assert PseudoPotentialFamily.objects.count() == 1
 
     family = PseudoPotentialFamily.objects.get(label=label)
-    assert isinstance(family.pseudos['Si'], UpfData)
+    assert isinstance(family.pseudos['Ar'], UpfData)
     assert family.__class__ is PseudoPotentialFamily
     assert family.description == description
     assert len(family.pseudos) != 0

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -16,7 +16,7 @@ from aiida_pseudo.groups.family import PseudoPotentialFamily
 def test_create_family_from_archive(get_pseudo_archive, fmt):
     """Test the `create_family_from_archive` utility function."""
     label = 'PSEUDO/0.0/LDA/extreme'
-    filepath_archive = next(get_pseudo_archive(fmt))
+    filepath_archive = get_pseudo_archive(fmt)
     family = create_family_from_archive(PseudoPotentialFamily, label, filepath_archive, fmt=fmt)
 
     assert isinstance(family, PseudoPotentialFamily)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,13 +205,13 @@ def get_pseudo_family(tmpdir, filepath_pseudos):
 
 
 @pytest.fixture
-def get_pseudo_archive(tmpdir, filepath_pseudos):
+def get_pseudo_archive(tmp_path, filepath_pseudos):
     """Create an archive with pseudos."""
 
     def _get_pseudo_archive(fmt='gztar'):
-        shutil.make_archive(str(tmpdir / 'archive'), fmt, filepath_pseudos('upf'))
-        filepath = os.path.join(str(tmpdir), os.listdir(str(tmpdir))[0])
-        yield filepath
+        shutil.make_archive(str(tmp_path / 'archive'), fmt, filepath_pseudos('upf'))
+        # The created archive should be the only file in ``tmp_path`` so just get first entry from the iterator.
+        return list(tmp_path.iterdir())[0]
 
     return _get_pseudo_archive
 


### PR DESCRIPTION
The `install family` command allows to install a family from an archive
that is directly provided via an HTTP URL. This was being tested
explicitly by using a URL from the Materials Cloud Archive. However,
this approach of actually retrieving from a URL has two main downsides:

 * It will be potentially slow by having to download data from the web
 * It is susceptible to random failures: if the URL is (temporarily) not
   availabe, goes permanently goes offline, or the content changes.

That is why we  monkeypatch the ``PathOrUrl`` instead to simply return
the content of an archive that is created on the fly on the local disk.
The command expects that the parameter type returns an object that
contains the content of the archive under the ``content`` attribute.
To mimick this, we construct a namedtuple with a ``content`` attribute
on the fly.