### PR TITLE
Update the `pre-commit` configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: trailing-whitespace
 
 -   repo: https://github.com/ikamensh/flynt/
-    rev: '0.55'
+    rev: '0.66'
     hooks:
     -   id: flynt
         args: [
@@ -17,28 +17,36 @@ repos:
             '--fail-on-change',
         ]
 
+-   repo: https://github.com/pycqa/isort
+    rev: 5.9.3
+    hooks:
+    -   id: isort
+
 -   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.30.0
+    rev: v0.31.0
     hooks:
     -   id: yapf
         name: yapf
         types: [python]
         args: ['-i']
+        additional_dependencies: ['toml']
         exclude: &exclude_files >
             (?x)^(
                 docs/.*|
             )$
 
--   repo: https://github.com/PyCQA/pylint
-    rev: pylint-2.6.0
-    hooks:
-    -   id: pylint
-        language: system
-        exclude: *exclude_files
-
 -   repo: https://github.com/PyCQA/pydocstyle
     rev: 5.0.2
     hooks:
     -   id: pydocstyle
-        args: ['--ignore=D104,D203,D213']
+        additional_dependencies: ['toml']
+        exclude: *exclude_files
+
+-   repo: local
+    hooks:
+    -   id: pylint
+        name: pylint
+        entry: pylint
+        types: [python]
+        language: system
         exclude: *exclude_files

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,8 +1,0 @@
-[style]
-align_closing_bracket_with_visual_indent = true
-based_on_style = google
-coalesce_brackets = true
-column_limit = 120
-dedent_closing_brackets = true
-indent_dictionary_value = false
-split_arguments_when_comma_terminated = true

--- a/aiida_pseudo/cli/__init__.py
+++ b/aiida_pseudo/cli/__init__.py
@@ -6,7 +6,7 @@ import click_completion
 # Activate the completion of parameter types provided by the click_completion package
 click_completion.init()
 
-from .root import cmd_root
 from .family import cmd_family
-from .install import cmd_install, cmd_install_family, cmd_install_sssp, cmd_install_pseudo_dojo
+from .install import cmd_install, cmd_install_family, cmd_install_pseudo_dojo, cmd_install_sssp
 from .list import cmd_list
+from .root import cmd_root

--- a/aiida_pseudo/cli/family.py
+++ b/aiida_pseudo/cli/family.py
@@ -2,10 +2,9 @@
 """Commands to inspect or modify the contents of pseudo potential families."""
 import json
 
-import click
-
 from aiida.cmdline.params import options as options_core
 from aiida.cmdline.utils import decorators, echo
+import click
 
 from ..groups.mixins import RecommendedCutoffMixin
 from .params import arguments, options

--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -4,15 +4,15 @@ import json
 import pathlib
 import shutil
 import tempfile
-import yaml
 
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.utils import decorators, echo
 import click
 import requests
-
-from aiida.cmdline.utils import decorators, echo
-from aiida.cmdline.params import options as options_core
+import yaml
 
 from aiida_pseudo.groups.family import PseudoDojoConfiguration, SsspConfiguration
+
 from .params import options, types
 from .root import cmd_root
 
@@ -103,6 +103,7 @@ def download_sssp(
     :return: Latest patch version of the requested minor version
     """
     from aiida_pseudo.groups.family import SsspFamily
+
     from .utils import attempt
 
     url_template = 'https://archive.materialscloud.org/record/file?filename={filename}&parent_id=19'
@@ -156,6 +157,7 @@ def download_pseudo_dojo(
     :param traceback: boolean, if true, print the traceback when an exception occurs.
     """
     from aiida_pseudo.groups.family import PseudoDojoFamily
+
     from .utils import attempt
 
     label = PseudoDojoFamily.format_configuration_label(configuration)
@@ -196,6 +198,7 @@ def cmd_install_sssp(version, functional, protocol, download_only, traceback):
 
     from aiida_pseudo import __version__
     from aiida_pseudo.groups.family import SsspFamily
+
     from .utils import attempt, create_family_from_archive
 
     configuration = SsspConfiguration(version, functional, protocol)
@@ -274,8 +277,9 @@ def cmd_install_pseudo_dojo(
     # pylint: disable=too-many-locals,too-many-arguments,too-many-branches,too-many-statements
     from aiida.common.files import md5_file
     from aiida.orm import Group, QueryBuilder
+
     from aiida_pseudo import __version__
-    from aiida_pseudo.data.pseudo import JthXmlData, Psp8Data, PsmlData, UpfData
+    from aiida_pseudo.data.pseudo import JthXmlData, PsmlData, Psp8Data, UpfData
     from aiida_pseudo.groups.family import PseudoDojoFamily
 
     from .utils import attempt, create_family_from_archive

--- a/aiida_pseudo/cli/list.py
+++ b/aiida_pseudo/cli/list.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Commands to list instances of `PseudoPotentialFamily`."""
-import click
 from aiida.cmdline.params import options as options_core
 from aiida.cmdline.utils import decorators, echo
+import click
 
 from .params import options
 from .root import cmd_root
@@ -17,6 +17,7 @@ def get_families_builder():
     :return: `QueryBuilder` instance
     """
     from aiida.orm import QueryBuilder
+
     from aiida_pseudo.groups.family import PseudoPotentialFamily
 
     builder = QueryBuilder().append(PseudoPotentialFamily)

--- a/aiida_pseudo/cli/params/arguments.py
+++ b/aiida_pseudo/cli/params/arguments.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Reusable arguments for CLI commands."""
 from aiida.cmdline.params.arguments import OverridableArgument
+
 from .types import PseudoPotentialFamilyParam
 
 __all__ = ('PSEUDO_POTENTIAL_FAMILY',)

--- a/aiida_pseudo/cli/params/options.py
+++ b/aiida_pseudo/cli/params/options.py
@@ -2,9 +2,9 @@
 """Reusable options for CLI commands."""
 import shutil
 
+from aiida.cmdline.params.options import OverridableOption
 import click
 
-from aiida.cmdline.params.options import OverridableOption
 from .types import PseudoPotentialFamilyTypeParam, PseudoPotentialTypeParam, UnitParamType
 
 __all__ = (

--- a/aiida_pseudo/cli/params/types.py
+++ b/aiida_pseudo/cli/params/types.py
@@ -4,12 +4,12 @@
 import pathlib
 import typing
 
+from aiida.cmdline.params.types import GroupParamType
 import click
 import requests
 
-from aiida.cmdline.params.types import GroupParamType
-from ..utils import attempt
 from ...common.units import U
+from ..utils import attempt
 
 __all__ = ('PseudoPotentialFamilyTypeParam', 'PseudoPotentialFamilyParam', 'PseudoPotentialTypeParam')
 
@@ -28,6 +28,7 @@ class PseudoPotentialTypeParam(click.ParamType):
         """
         from aiida.common import exceptions
         from aiida.plugins import DataFactory
+
         from aiida_pseudo.data.pseudo import PseudoPotentialData
 
         try:
@@ -80,6 +81,7 @@ class PseudoPotentialFamilyTypeParam(click.ParamType):
         """
         from aiida.common import exceptions
         from aiida.plugins import GroupFactory
+
         from aiida_pseudo.groups.family import PseudoPotentialFamily
 
         try:

--- a/aiida_pseudo/cli/root.py
+++ b/aiida_pseudo/cli/root.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Command line interface `aiida-pseudo`."""
-import click
-
 from aiida.cmdline.params import options, types
+import click
 
 
 @click.group('aiida-pseudo', context_settings={'help_option_names': ['-h', '--help']})

--- a/aiida_pseudo/common/__init__.py
+++ b/aiida_pseudo/common/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Module with common resources."""

--- a/aiida_pseudo/data/__init__.py
+++ b/aiida_pseudo/data/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Module with implementations of :class:`aiida.orm.nodes.data.Data` plugins."""

--- a/aiida_pseudo/data/pseudo/pseudo.py
+++ b/aiida_pseudo/data/pseudo/pseudo.py
@@ -4,8 +4,7 @@ import io
 import pathlib
 import typing
 
-from aiida import orm
-from aiida import plugins
+from aiida import orm, plugins
 from aiida.common.constants import elements
 from aiida.common.exceptions import StoringNotAllowed
 from aiida.common.files import md5_from_filelike

--- a/aiida_pseudo/groups/__init__.py
+++ b/aiida_pseudo/groups/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Module with implementations of :class:`aiida.orm.groups.Group` plugins."""

--- a/aiida_pseudo/groups/family/pseudo.py
+++ b/aiida_pseudo/groups/family/pseudo.py
@@ -2,7 +2,7 @@
 """Subclass of ``Group`` that serves as a base class for representing pseudo potential families."""
 import os
 import re
-from typing import Union, List, Tuple, Mapping
+from typing import List, Mapping, Tuple, Union
 
 from aiida.common import exceptions
 from aiida.common.lang import classproperty, type_check

--- a/aiida_pseudo/groups/family/pseudo_dojo.py
+++ b/aiida_pseudo/groups/family/pseudo_dojo.py
@@ -2,15 +2,15 @@
 """Subclass of `PseudoPotentialFamily` designed to represent a PseudoDojo configuration."""
 import json
 import os
+from pathlib import Path
 import re
 from typing import NamedTuple, Sequence
 import warnings
 
-from pathlib import Path
-
 from aiida.common.exceptions import ParsingError
 
-from aiida_pseudo.data.pseudo import UpfData, PsmlData, Psp8Data, JthXmlData
+from aiida_pseudo.data.pseudo import JthXmlData, PsmlData, Psp8Data, UpfData
+
 from ..mixins import RecommendedCutoffMixin
 from .pseudo import PseudoPotentialFamily
 
@@ -285,7 +285,7 @@ class PseudoDojoFamily(RecommendedCutoffMixin, PseudoPotentialFamily):
                 continue
 
             try:
-                with open(filepath, 'r') as handle:
+                with open(filepath, 'r', encoding='utf-8') as handle:
                     djrepo = json.load(handle)
             except ParsingError as exception:
                 raise ParsingError(f'failed to parse `{filepath}`: {exception}') from exception

--- a/aiida_pseudo/groups/family/sssp.py
+++ b/aiida_pseudo/groups/family/sssp.py
@@ -3,6 +3,7 @@
 from typing import NamedTuple, Optional, Sequence
 
 from aiida_pseudo.data.pseudo import UpfData
+
 from ..mixins import RecommendedCutoffMixin
 from .pseudo import PseudoPotentialFamily
 

--- a/aiida_pseudo/groups/mixins/cutoffs.py
+++ b/aiida_pseudo/groups/mixins/cutoffs.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Mixin that adds support of recommended cutoffs to a ``Group`` subclass, using its extras."""
-import warnings
-
 from typing import Optional
+import warnings
 
 from aiida.common.lang import type_check
 from aiida.plugins import DataFactory

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 from reentry import manager
+
 manager.scan()
 
 # -- Path setup --------------------------------------------------------------
@@ -16,6 +17,7 @@ manager.scan()
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../../'))
 
 import aiida_pseudo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,22 @@
 [build-system]
-requires = ['setuptools>=40.8.0', 'wheel', 'reentry~=1.3', 'fastentrypoints~=0.12']
-build-backend = 'setuptools.build_meta:__legacy__'
+requires = ['setuptools>=40.8.0', 'wheel', 'fastentrypoints~=0.12']
+build-backend = 'setuptools.build_meta'
+
+[tool.isort]
+force_sort_within_sections = true
+include_trailing_comma = true
+line_length = 120
+multi_line_output = 3
+
+[tool.pydocstyle]
+ignore = [
+    'D104',
+    'D203',
+    'D213',
+]
+
+[tool.pylint.master]
+load-plugins = ['pylint_aiida']
 
 [tool.pylint.format]
 max-line-length = 120
@@ -12,3 +28,21 @@ disable = [
     'import-outside-toplevel',
     'too-many-arguments',
 ]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    'ignore::DeprecationWarning:distutils:',
+    'ignore::DeprecationWarning:frozendict:',
+    'ignore::DeprecationWarning:sqlalchemy_utils:',
+    'ignore::DeprecationWarning:reentry:',
+    'ignore::DeprecationWarning:pkg_resources:',
+]
+
+[tool.yapf]
+align_closing_bracket_with_visual_indent = true
+based_on_style = 'google'
+coalesce_brackets = true
+column_limit = 120
+dedent_closing_brackets = true
+indent_dictionary_value = false
+split_arguments_when_comma_terminated = true

--- a/setup.json
+++ b/setup.json
@@ -46,7 +46,8 @@
     "extras_require": {
         "pre-commit": [
             "pre-commit~=2.2",
-            "pylint~=2.6.0"
+            "pylint~=2.6",
+            "pylint-aiida~=0.1"
         ],
         "tests": [
             "pgtest~=1.3",

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,16 @@ except ImportError:
 def setup_package():
     """Install the `aiida-pseudo` package."""
     import json
-    from setuptools import setup, find_packages
+
+    from setuptools import find_packages, setup
 
     filename_setup_json = 'setup.json'
     filename_description = 'README.md'
 
-    with open(filename_setup_json, 'r') as handle:
+    with open(filename_setup_json, 'r', encoding='utf-8') as handle:
         setup_json = json.load(handle)
 
-    with open(filename_description, 'r') as handle:
+    with open(filename_description, 'r', encoding='utf-8') as handle:
         description = handle.read()
 
     setup(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_pseudo` module."""

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_pseudo.cli` module."""

--- a/tests/cli/params/__init__.py
+++ b/tests/cli/params/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_pseudo.cli.params` module."""

--- a/tests/cli/test_family.py
+++ b/tests/cli/test_family.py
@@ -3,13 +3,12 @@
 """Tests for the command `aiida-pseudo family`."""
 import json
 
+from aiida.orm import Group
 from numpy.testing import assert_almost_equal
 import pytest
 
-from aiida.orm import Group
-
 from aiida_pseudo.cli.family import cmd_family_cutoffs_set, cmd_family_show
-from aiida_pseudo.groups.family import PseudoPotentialFamily, CutoffsPseudoPotentialFamily
+from aiida_pseudo.groups.family import CutoffsPseudoPotentialFamily, PseudoPotentialFamily
 
 
 @pytest.mark.usefixtures('clear_db')

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -4,16 +4,14 @@
 import json
 import pathlib
 
+from aiida.orm import QueryBuilder
 import pytest
 
-from aiida.orm import QueryBuilder
-
-from aiida_pseudo.cli import install
-from aiida_pseudo.cli import cmd_install_family, cmd_install_sssp, cmd_install_pseudo_dojo
+from aiida_pseudo.cli import cmd_install_family, cmd_install_pseudo_dojo, cmd_install_sssp, install
 from aiida_pseudo.data.pseudo.upf import UpfData
 from aiida_pseudo.groups.family import PseudoPotentialFamily
-from aiida_pseudo.groups.family.pseudo_dojo import PseudoDojoFamily, PseudoDojoConfiguration
-from aiida_pseudo.groups.family.sssp import SsspFamily, SsspConfiguration
+from aiida_pseudo.groups.family.pseudo_dojo import PseudoDojoConfiguration, PseudoDojoFamily
+from aiida_pseudo.groups.family.sssp import SsspConfiguration, SsspFamily
 
 
 @pytest.fixture
@@ -49,7 +47,7 @@ def run_monkeypatched_install_sssp(run_cli_command, get_pseudo_potential_data, m
         filename_archive = shutil.make_archive('temparchive', 'gztar', root_dir=tmpdir, base_dir='.')
         shutil.move(pathlib.Path.cwd() / filename_archive, filepath_archive)
 
-        with open(filepath_metadata, 'w') as handle:
+        with open(filepath_metadata, 'w', encoding='utf-8') as handle:
             data = {element: {'md5': md5, 'cutoff_wfc': 60.0, 'cutoff_rho': 240.0}}
             json.dump(data, handle)
             handle.flush()
@@ -98,7 +96,7 @@ def run_monkeypatched_install_pseudo_dojo(run_cli_command, get_pseudo_potential_
 
         filepath_djrepo = tmpdir / f'{element}.djrepo'
 
-        with open(filepath_djrepo, 'w') as handle:
+        with open(filepath_djrepo, 'w', encoding='utf-8') as handle:
             json.dump(data, handle)
             handle.flush()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,12 @@ import os
 import re
 import shutil
 
+from aiida.plugins import DataFactory
 import click
 import pytest
 
-from aiida.plugins import DataFactory
-
 from aiida_pseudo.data.pseudo import PseudoPotentialData
-from aiida_pseudo.groups.family import PseudoPotentialFamily, CutoffsPseudoPotentialFamily
+from aiida_pseudo.groups.family import CutoffsPseudoPotentialFamily, PseudoPotentialFamily
 
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
 
@@ -51,6 +50,7 @@ def run_cli_command():
         :param raises: optionally an exception class that is expected to be raised
         """
         import traceback
+
         from click.testing import CliRunner
 
         runner = CliRunner()

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_pseudo.data` module."""

--- a/tests/data/pseudo/__init__.py
+++ b/tests/data/pseudo/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_pseudo.data.pseudo` module."""

--- a/tests/data/pseudo/test_common.py
+++ b/tests/data/pseudo/test_common.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
 """Tests that are common to all data plugins in the :py:mod:`~aiida_pseudo.data.pseudo` module."""
-import pytest
-
 from aiida import plugins
+import pytest
 
 
 def get_entry_point_names():

--- a/tests/data/pseudo/test_jthxml.py
+++ b/tests/data/pseudo/test_jthxml.py
@@ -5,9 +5,9 @@ import io
 import os
 import pathlib
 
+from aiida.common.exceptions import ModificationNotAllowed
 import pytest
 
-from aiida.common.exceptions import ModificationNotAllowed
 from aiida_pseudo.data.pseudo import JthXmlData
 
 

--- a/tests/data/pseudo/test_pseudo.py
+++ b/tests/data/pseudo/test_pseudo.py
@@ -4,12 +4,11 @@
 import io
 import pathlib
 
-import pytest
-
-from aiida.common.files import md5_from_filelike
 from aiida.common.exceptions import ModificationNotAllowed, StoringNotAllowed
+from aiida.common.files import md5_from_filelike
 from aiida.common.links import LinkType
 from aiida.orm import CalcJobNode
+import pytest
 
 from aiida_pseudo.data.pseudo import PseudoPotentialData, UpfData
 

--- a/tests/data/pseudo/test_psf.py
+++ b/tests/data/pseudo/test_psf.py
@@ -5,9 +5,9 @@ import io
 import os
 import pathlib
 
+from aiida.common.exceptions import ModificationNotAllowed
 import pytest
 
-from aiida.common.exceptions import ModificationNotAllowed
 from aiida_pseudo.data.pseudo import PsfData
 from aiida_pseudo.data.pseudo.psf import parse_element
 

--- a/tests/data/pseudo/test_psml.py
+++ b/tests/data/pseudo/test_psml.py
@@ -5,9 +5,9 @@ import io
 import os
 import pathlib
 
+from aiida.common.exceptions import ModificationNotAllowed
 import pytest
 
-from aiida.common.exceptions import ModificationNotAllowed
 from aiida_pseudo.data.pseudo import PsmlData
 
 

--- a/tests/data/pseudo/test_psp8.py
+++ b/tests/data/pseudo/test_psp8.py
@@ -5,9 +5,9 @@ import io
 import os
 import pathlib
 
+from aiida.common.exceptions import ModificationNotAllowed
 import pytest
 
-from aiida.common.exceptions import ModificationNotAllowed
 from aiida_pseudo.data.pseudo import Psp8Data
 
 

--- a/tests/data/pseudo/test_upf.py
+++ b/tests/data/pseudo/test_upf.py
@@ -5,9 +5,9 @@ import io
 import os
 import pathlib
 
+from aiida.common.exceptions import ModificationNotAllowed
 import pytest
 
-from aiida.common.exceptions import ModificationNotAllowed
 from aiida_pseudo.data.pseudo import UpfData
 from aiida_pseudo.data.pseudo.upf import parse_z_valence
 

--- a/tests/data/pseudo/test_vps.py
+++ b/tests/data/pseudo/test_vps.py
@@ -5,11 +5,11 @@ import io
 import os
 import pathlib
 
+from aiida.common.exceptions import ModificationNotAllowed
 import pytest
 
-from aiida.common.exceptions import ModificationNotAllowed
 from aiida_pseudo.data.pseudo import VpsData
-from aiida_pseudo.data.pseudo.vps import parse_z_valence, parse_xc_type
+from aiida_pseudo.data.pseudo.vps import parse_xc_type, parse_z_valence
 
 
 @pytest.fixture

--- a/tests/groups/__init__.py
+++ b/tests/groups/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_pseudo.groups` module."""

--- a/tests/groups/family/__init__.py
+++ b/tests/groups/family/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_pseudo.groups.family` module."""

--- a/tests/groups/family/test_pseudo.py
+++ b/tests/groups/family/test_pseudo.py
@@ -4,10 +4,9 @@
 import distutils.dir_util
 import os
 
-import pytest
-
 from aiida.common import exceptions
 from aiida.orm import QueryBuilder
+import pytest
 
 from aiida_pseudo.data.pseudo import PseudoPotentialData
 from aiida_pseudo.groups.family.pseudo import PseudoPotentialFamily

--- a/tests/groups/family/test_pseudo_dojo.py
+++ b/tests/groups/family/test_pseudo_dojo.py
@@ -3,7 +3,7 @@
 """Tests for the `PseudoDojoFamily` class."""
 import pytest
 
-from aiida_pseudo.data.pseudo import UpfData, Psp8Data, PsmlData, JthXmlData
+from aiida_pseudo.data.pseudo import JthXmlData, PsmlData, Psp8Data, UpfData
 from aiida_pseudo.groups.family import PseudoDojoConfiguration, PseudoDojoFamily
 
 

--- a/tests/groups/mixins/__init__.py
+++ b/tests/groups/mixins/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_pseudo.groups.mixins` module."""

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore::DeprecationWarning:distutils:
-    ignore::DeprecationWarning:frozendict:
-    ignore::DeprecationWarning:sqlalchemy_utils:
-    ignore::DeprecationWarning:reentry:
-    ignore::DeprecationWarning:pkg_resources:


### PR DESCRIPTION
The pre-commit is updated and improved in various ways:

 * Configuration is moved from tool specific configuration files to the
   standard `pyproject.toml`. This allows to remove `.style.yapf` and
   `pytest.ini`.
 * Update `yapf` requirement to `v0.31.0` which is necessary for the
   `pyproject.toml` support.
 * Add the `isort` hook to organize imports.
 * Add the `flynt` hook to automatically fix f-strings.