### PR TITLE
Dependencies: update and pin `pylint==2.13.7`

### DIFF
--- a/aiida_pseudo/data/pseudo/pseudo.py
+++ b/aiida_pseudo/data/pseudo/pseudo.py
@@ -37,7 +37,7 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
         existing = query.first()
 
         if existing:
-            pseudo = existing[0]
+            pseudo = existing[0]  # pylint: disable=unsubscriptable-object
         else:
             source.seek(0)
             pseudo = cls(source, filename)

--- a/aiida_pseudo/groups/family/pseudo.py
+++ b/aiida_pseudo/groups/family/pseudo.py
@@ -172,13 +172,10 @@ class PseudoPotentialFamily(Group):
         """
         type_check(description, str, allow_none=True)
 
-        try:
-            cls.objects.get(label=label)
-        except exceptions.NotExistent:
-            family = cls(label=label, description=description)
-        else:
+        if cls.objects.count(filters={'label': label}):
             raise ValueError(f'the {cls.__name__} `{label}` already exists')
 
+        family = cls(label=label, description=description)
         pseudos = cls.parse_pseudos_from_directory(dirpath, pseudo_type, deduplicate=deduplicate)
 
         # Only store the ``Group`` and the pseudo nodes now, such that we don't have to worry about the clean up in the

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ docs =
     sphinx-click~=2.7.1
 pre-commit =
     pre-commit~=2.2
-    pylint~=2.6
+    pylint==2.13.7
     pylint-aiida~=0.1
 tests =
     pgtest~=1.3


### PR DESCRIPTION
To guarantee the reproducibility of local pre-commit as well as that of
the remote CI workflows, it is best to pin a version of `pylint`. Here
it is updated to the most recent version. This surfaces two new warnings
that are addressed.