### PR TITLE
DevOps: Update Python version requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         -   name: Set up Python
             uses: actions/setup-python@v2
             with:
-                python-version: 3.8
+                python-version: '3.9'
 
         -   name: Install python dependencies
             run:
@@ -40,7 +40,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.6, 3.7, 3.8, 3.9]
+                python-version: ['3.8', '3.9', '3.10']
 
         services:
             rabbitmq:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,15 +16,14 @@ classifiers =
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 include_package_data = True
 packages = find:
-python_requires >= 3.6
+python_requires >= 3.8
 install_requires =
     aiida-core~=1.4
     click~=7.0
@@ -47,7 +46,7 @@ pre-commit =
     pylint-aiida~=0.1
 tests =
     pgtest~=1.3
-    pytest~=5.4
+    pytest>=6.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The Python requirements are updated:

 * Drop support for Python 3.6 and Python 3.7
 * Add support for Python 3.10

To add support for Python 3.10, the minimum requirement for `pytest`
also had to be updated.