### PR TITLE
DevOps: Add proper file extension to license file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 AiiDA Developers
+Copyright (c) 2022 AiiDA Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = 'aiida-pseudo'
 dynamic = ['description', 'version']
 authors = [{name = 'Sebastiaan P. Huber', email = 'mail@sphuber.net'}]
 readme = 'README.md'
-license = {file = 'LICENSE'}
+license = {file = 'LICENSE.txt'}
 classifiers = [
     'Development Status :: 4 - Beta',
     'Framework :: AiiDA',


### PR DESCRIPTION
The license file was named `LICENSE` but having `LICENSE.txt` with a
proper extension is better. The copyright year is also updated as well
as the reference to the license file in the `pyproject.toml`.