### PR TITLE
Dependencies: update requirement `aiida-core~=2.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: continuous-integration
+name: ci
 
 on: [push, pull_request]
 
@@ -11,8 +11,7 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache python dependencies
-            id: cache-pip
+        -   name: Cache Python dependencies
             uses: actions/cache@v1
             with:
                 path: ~/.cache/pip
@@ -25,13 +24,11 @@ jobs:
             with:
                 python-version: '3.9'
 
-        -   name: Install python dependencies
-            run:
-                pip install -e .[pre-commit,tests]
+        -   name: Install Python dependencies
+            run: pip install -e .[pre-commit,tests]
 
         -   name: Run pre-commit
-            run:
-                pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+            run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
     tests:
 
@@ -43,6 +40,8 @@ jobs:
                 python-version: ['3.8', '3.9', '3.10']
 
         services:
+            postgres:
+                image: postgres:12
             rabbitmq:
                 image: rabbitmq:latest
                 ports:
@@ -51,8 +50,7 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache python dependencies
-            id: cache-pip
+        -   name: Cache Python dependencies
             uses: actions/cache@v1
             with:
                 path: ~/.cache/pip
@@ -65,17 +63,10 @@ jobs:
             with:
                 python-version: ${{ matrix.python-version }}
 
-        -   name: Install system dependencies
-            run: |
-                sudo apt update
-                sudo apt install postgresql
-
-        -   name: Install python dependencies
-            run: |
-                pip install --upgrade setuptools
-                pip install -e .[tests]
-                reentry scan
+        -   name: Install Python dependencies
+            run: pip install -e .[tests]
 
         -   name: Run pytest
-            run:
-                pytest -sv tests
+            env:
+                AIIDA_WARN_v3: True
+            run: pytest -sv tests

--- a/aiida_pseudo/cli/__init__.py
+++ b/aiida_pseudo/cli/__init__.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=wrong-import-position,wildcard-import
 """Module for the command line interface."""
-import click_completion
-
-# Activate the completion of parameter types provided by the click_completion package
-click_completion.init()
-
 from .family import cmd_family
 from .install import cmd_install, cmd_install_family, cmd_install_pseudo_dojo, cmd_install_sssp
 from .list import cmd_list

--- a/aiida_pseudo/cli/install.py
+++ b/aiida_pseudo/cli/install.py
@@ -244,7 +244,7 @@ def cmd_install_sssp(version, functional, protocol, download_only, traceback):
 
         for element, values in metadata.items():
             if family.get_pseudo(element).md5 != values['md5']:
-                Group.objects.delete(family.pk)
+                Group.collection.delete(family.pk)
                 msg = f"md5 of pseudo for element {element} does not match that of the metadata {values['md5']}"
                 echo.echo_critical(msg)
 
@@ -345,7 +345,7 @@ def cmd_install_pseudo_dojo(
 
         for element, md5 in md5s.items():
             if family.get_pseudo(element).md5 != md5:
-                Group.objects.delete(family.pk)
+                Group.collection.delete(family.pk)
                 msg = f'md5 of pseudo for element {element} does not match that of the metadata {md5}'
                 echo.echo_critical(msg)
 

--- a/aiida_pseudo/cli/list.py
+++ b/aiida_pseudo/cli/list.py
@@ -39,7 +39,7 @@ def cmd_list(project, raw, family_type):
     }
 
     if get_families_builder().count() == 0:
-        echo.echo_info('no pseudo potential families have been installed yet: use `aiida-pseudo install`.')
+        echo.echo_report('no pseudo potential families have been installed yet: use `aiida-pseudo install`.')
         return
 
     rows = []
@@ -61,7 +61,7 @@ def cmd_list(project, raw, family_type):
         rows.append(row)
 
     if not rows:
-        echo.echo_info('no pseudo potential families found that match the filtering criteria.')
+        echo.echo_report('no pseudo potential families found that match the filtering criteria.')
         return
 
     if raw:

--- a/aiida_pseudo/cli/params/arguments.py
+++ b/aiida_pseudo/cli/params/arguments.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Reusable arguments for CLI commands."""
-from aiida.cmdline.params.arguments import OverridableArgument
+from aiida.cmdline.params.arguments.overridable import OverridableArgument
 
 from .types import PseudoPotentialFamilyParam
 

--- a/aiida_pseudo/cli/root.py
+++ b/aiida_pseudo/cli/root.py
@@ -4,7 +4,43 @@ from aiida.cmdline.params import options, types
 import click
 
 
+class VerbosityGroup(click.Group):
+    """Custom command group that automatically adds the ``VERBOSITY`` option to all subcommands."""
+
+    @staticmethod
+    def add_verbosity_option(cmd):
+        """Apply the ``verbosity`` option to the command, which is common to all ``verdi`` commands."""
+        if 'verbosity' not in [param.name for param in cmd.params]:
+            cmd = options.VERBOSITY()(cmd)
+
+        return cmd
+
+    def group(self, *args, **kwargs):
+        """Ensure that sub command groups use the same class but do not override an explicitly set value."""
+        kwargs.setdefault('cls', self.__class__)
+        return super().group(*args, **kwargs)
+
+    def get_command(self, ctx, cmd_name):
+        """Return the command that corresponds to the requested ``cmd_name``.
+
+        This method is overridden from the base class in order to automatically add the verbosity option.
+
+        Note that if the command is not found and ``resilient_parsing`` is set to True on the context, then the latter
+        feature is disabled because most likely we are operating in tab-completion mode.
+        """
+        cmd = super().get_command(ctx, cmd_name)
+
+        if cmd is not None:
+            return self.add_verbosity_option(cmd)
+
+        if ctx.resilient_parsing:
+            return None
+
+        return ctx.fail(f'`{cmd_name}` is not a {self.name} command.')
+
+
 @click.group('aiida-pseudo', context_settings={'help_option_names': ['-h', '--help']})
-@options.PROFILE(type=types.ProfileParamType(load_profile=True))
-def cmd_root(profile):  # pylint: disable=unused-argument
+@options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
+@options.VERBOSITY()
+def cmd_root():
     """CLI for the ``aiida-pseudo`` plugin."""

--- a/aiida_pseudo/cli/utils.py
+++ b/aiida_pseudo/cli/utils.py
@@ -18,18 +18,18 @@ def attempt(message, exception_types=Exception, include_traceback=False):
     import sys
     import traceback
 
-    echo.echo_info(message, nl=False)
+    echo.echo_report(message, nl=False)
 
     try:
         yield
     except exception_types as exception:  # pylint: disable=broad-except
-        echo.echo_highlight(' [FAILED]', color='error', bold=True)
+        echo.echo(' [FAILED]', fg='red', bold=True)
         message = str(exception)
         if include_traceback:
             message += f"\n{''.join(traceback.format_exception(*sys.exc_info()))}"
         echo.echo_critical(message)
     else:
-        echo.echo_highlight(' [OK]', color='success', bold=True)
+        echo.echo(' [OK]', fg='green', bold=True)
 
 
 def create_family_from_archive(cls, label, filepath_archive: Path, fmt=None, pseudo_type=None):

--- a/aiida_pseudo/data/pseudo/pseudo.py
+++ b/aiida_pseudo/data/pseudo/pseudo.py
@@ -12,7 +12,7 @@ from aiida.common.files import md5_from_filelike
 __all__ = ('PseudoPotentialData',)
 
 
-class PseudoPotentialData(plugins.DataFactory('singlefile')):
+class PseudoPotentialData(plugins.DataFactory('core.singlefile')):
     """Base class for data types representing pseudo potentials."""
 
     _key_element = 'element'
@@ -34,11 +34,9 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
         query = orm.QueryBuilder()
         query.append(cls, subclassing=False, filters={f'attributes.{cls._key_md5}': md5_from_filelike(source)})
 
-        existing = query.first()
+        pseudo = query.first(flat=True)
 
-        if existing:
-            pseudo = existing[0]  # pylint: disable=unsubscriptable-object
-        else:
+        if not pseudo:
             source.seek(0)
             pseudo = cls(source, filename)
 
@@ -155,7 +153,7 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
 
         :return: the symbol of the element following the IUPAC naming standard or None if not defined.
         """
-        return self.get_attribute(self._key_element, None)
+        return self.base.attributes.get(self._key_element, None)
 
     @element.setter
     def element(self, value: str):
@@ -165,7 +163,7 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
         :raises ValueError: if the element symbol is invalid.
         """
         self.validate_element(value)
-        self.set_attribute(self._key_element, value)
+        self.base.attributes.set(self._key_element, value)
 
     @property
     def md5(self) -> typing.Optional[int]:
@@ -173,7 +171,7 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
 
         :return: the md5 of the stored file.
         """
-        return self.get_attribute(self._key_md5, None)
+        return self.base.attributes.get(self._key_md5, None)
 
     @md5.setter
     def md5(self, value: str):
@@ -183,4 +181,4 @@ class PseudoPotentialData(plugins.DataFactory('singlefile')):
         :raises ValueError: if the md5 does not match that of the currently stored file.
         """
         self.validate_md5(value)
-        self.set_attribute(self._key_md5, value)
+        self.base.attributes.set(self._key_md5, value)

--- a/aiida_pseudo/data/pseudo/upf.py
+++ b/aiida_pseudo/data/pseudo/upf.py
@@ -95,7 +95,7 @@ class UpfData(PseudoPotentialData):
 
         :return: the Z valence.
         """
-        return self.get_attribute(self._key_z_valence, None)
+        return self.base.attributes.get(self._key_z_valence, None)
 
     @z_valence.setter
     def z_valence(self, value: int):
@@ -107,4 +107,4 @@ class UpfData(PseudoPotentialData):
         if not isinstance(value, int) or value < 0:
             raise ValueError(f'`{value}` is not a positive integer')
 
-        self.set_attribute(self._key_z_valence, value)
+        self.base.attributes.set(self._key_z_valence, value)

--- a/aiida_pseudo/data/pseudo/vps.py
+++ b/aiida_pseudo/data/pseudo/vps.py
@@ -135,7 +135,7 @@ class VpsData(PseudoPotentialData):
 
         :return: the Z valence.
         """
-        return self.get_attribute(self._key_z_valence, None)
+        return self.base.attributes.get(self._key_z_valence, None)
 
     @z_valence.setter
     def z_valence(self, value: int):
@@ -147,7 +147,7 @@ class VpsData(PseudoPotentialData):
         if not isinstance(value, int) or value < 0:
             raise ValueError(f'`{value}` is not a positive integer.')
 
-        self.set_attribute(self._key_z_valence, value)
+        self.base.attributes.set(self._key_z_valence, value)
 
     @property
     def xc_type(self) -> typing.Optional[int]:
@@ -155,7 +155,7 @@ class VpsData(PseudoPotentialData):
 
         :return: the exchange-correlation type.
         """
-        return self.get_attribute(self._key_xc_type, None)
+        return self.base.attributes.get(self._key_xc_type, None)
 
     @xc_type.setter
     def xc_type(self, value: str):
@@ -167,4 +167,4 @@ class VpsData(PseudoPotentialData):
         if not isinstance(value, str) or value not in VALID_XC_TYPES:
             raise ValueError(f'`{value}` is not a valid OpenMX XcType string.')
 
-        self.set_attribute(self._key_xc_type, value)
+        self.base.attributes.set(self._key_xc_type, value)

--- a/aiida_pseudo/groups/family/pseudo.py
+++ b/aiida_pseudo/groups/family/pseudo.py
@@ -13,7 +13,7 @@ from aiida_pseudo.data.pseudo import PseudoPotentialData
 
 __all__ = ('PseudoPotentialFamily',)
 
-StructureData = DataFactory('structure')
+StructureData = DataFactory('core.structure')
 
 
 class PseudoPotentialFamily(Group):
@@ -172,7 +172,7 @@ class PseudoPotentialFamily(Group):
         """
         type_check(description, str, allow_none=True)
 
-        if cls.objects.count(filters={'label': label}):
+        if cls.collection.count(filters={'label': label}):
             raise ValueError(f'the {cls.__name__} `{label}` already exists')
 
         family = cls(label=label, description=description)
@@ -191,7 +191,7 @@ class PseudoPotentialFamily(Group):
 
         :return: the pseudopotential type or ``None`` if none has been set yet.
         """
-        return self.get_extra(self._key_pseudo_type, None)
+        return self.base.extras.get(self._key_pseudo_type, None)
 
     def update_pseudo_type(self):
         """Update the pseudo type, stored as an extra, based on the current nodes in the family."""
@@ -203,7 +203,7 @@ class PseudoPotentialFamily(Group):
         else:
             entry_point_name = None
 
-        self.set_extra(self._key_pseudo_type, entry_point_name)
+        self.base.extras.set(self._key_pseudo_type, entry_point_name)
 
     def add_nodes(self, nodes):
         """Add a node or a set of nodes to the family.

--- a/aiida_pseudo/groups/mixins/cutoffs.py
+++ b/aiida_pseudo/groups/mixins/cutoffs.py
@@ -8,7 +8,7 @@ from aiida.plugins import DataFactory
 
 from aiida_pseudo.common.units import U
 
-StructureData = DataFactory('structure')  # pylint: disable=invalid-name
+StructureData = DataFactory('core.structure')  # pylint: disable=invalid-name
 
 __all__ = ('RecommendedCutoffMixin',)
 
@@ -105,14 +105,14 @@ class RecommendedCutoffMixin:
 
         :return: the cutoffs extra or an empty dictionary if it has not yet been set.
         """
-        return self.get_extra(self._key_cutoffs, {})
+        return self.base.extras.get(self._key_cutoffs, {})
 
     def _get_cutoffs_unit_dict(self) -> dict:
         """Return the cutoffs units for each of the stringencies.
 
         :return: the cutoffs units extra or an empty dictionary if it has not yet been set.
         """
-        return self.get_extra(self._key_cutoffs_unit, {})
+        return self.base.extras.get(self._key_cutoffs_unit, {})
 
     def get_default_stringency(self) -> str:
         """Return the default stringency if defined.
@@ -121,7 +121,7 @@ class RecommendedCutoffMixin:
         :raises ValueError: if default stringency has not been defined.
         """
         try:
-            return self.get_extra(self._key_default_stringency)
+            return self.base.extras.get(self._key_default_stringency)
         except AttributeError as exception:
             raise ValueError('no default stringency has been defined.') from exception
 
@@ -137,7 +137,7 @@ class RecommendedCutoffMixin:
             raise ValueError('the default stringency cannot be unset.')
 
         self.validate_stringency(default_stringency)
-        self.set_extra(self._key_default_stringency, default_stringency)
+        self.base.extras.set(self._key_default_stringency, default_stringency)
 
     def get_cutoff_stringencies(self) -> tuple:
         """Return a tuple of the available cutoff stringencies.
@@ -183,8 +183,8 @@ class RecommendedCutoffMixin:
         cutoffs_unit_dict = self._get_cutoffs_unit_dict()
         cutoffs_unit_dict[stringency] = unit
 
-        self.set_extra(self._key_cutoffs, cutoffs_dict)
-        self.set_extra(self._key_cutoffs_unit, cutoffs_unit_dict)
+        self.base.extras.set(self._key_cutoffs, cutoffs_dict)
+        self.base.extras.set(self._key_cutoffs_unit, cutoffs_unit_dict)
         if len(cutoffs_dict) == 1:
             self.set_default_stringency(stringency)
 
@@ -218,8 +218,8 @@ class RecommendedCutoffMixin:
         cutoffs_unit_dict = self._get_cutoffs_unit_dict()
         cutoffs_unit_dict.pop(stringency, None)  # `None` is added to support pseudo families installed with v0.5.0
 
-        self.set_extra(self._key_cutoffs, cutoffs_dict)
-        self.set_extra(self._key_cutoffs_unit, cutoffs_unit_dict)
+        self.base.extras.set(self._key_cutoffs, cutoffs_dict)
+        self.base.extras.set(self._key_cutoffs_unit, cutoffs_unit_dict)
 
         warning = ''
         try:
@@ -268,7 +268,7 @@ class RecommendedCutoffMixin:
             # Workaround to deal with pseudo families installed in v0.5.0 - Set default unit in case it is not in extras
             cutoffs_unit_dict = self._get_cutoffs_unit_dict()
             cutoffs_unit_dict[stringency] = 'eV'
-            self.set_extra(self._key_cutoffs_unit, cutoffs_unit_dict)
+            self.base.extras.set(self._key_cutoffs_unit, cutoffs_unit_dict)
             return 'eV'
             # End of workaround
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,10 +5,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-from reentry import manager
-
-manager.scan()
-
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,9 @@ classifiers = [
 keywords = ['aiida', 'pseudopotentials']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core~=1.4',
-    'click~=7.0',
-    'click-completion~=0.5',
+    'aiida-core~=2.0',
+    'click~=8.0',
     'pint~=0.16.1',
-    'psycopg2-binary<2.9',
     'requests~=2.20',
 ]
 
@@ -37,12 +35,11 @@ Documentation = 'https://aiida-pseudo.readthedocs.io'
 
 [project.optional-dependencies]
 docs = [
-    'docutils~=0.17.0',
-    'sphinx~=3.2',
-    'sphinx-copybutton~=0.3.0',
-    'sphinx-book-theme~=0.0.39',
+    'sphinx~=4.1',
+    'sphinx-copybutton~=0.5.0',
+    'sphinx-book-theme~=0.3.2',
     'sphinx-autoapi~=1.8.1',
-    'sphinx-click~=2.7.1',
+    'sphinx-click~=4.0',
 ]
 pre-commit = [
     'pre-commit~=2.2',
@@ -123,7 +120,6 @@ filterwarnings = [
     'ignore::DeprecationWarning:distutils:',
     'ignore::DeprecationWarning:frozendict:',
     'ignore::DeprecationWarning:sqlalchemy_utils:',
-    'ignore::DeprecationWarning:reentry:',
     'ignore::DeprecationWarning:pkg_resources:',
 ]
 

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -120,9 +120,9 @@ def test_install_family(run_cli_command, get_pseudo_archive):
 
     result = run_cli_command(cmd_install_family, options)
     assert f'installed `{label}`' in result.output
-    assert PseudoPotentialFamily.objects.count() == 1
+    assert PseudoPotentialFamily.collection.count() == 1
 
-    family = PseudoPotentialFamily.objects.get(label=label)
+    family = PseudoPotentialFamily.collection.get(label=label)
     assert family.__class__ is PseudoPotentialFamily
     assert family.description == description
     assert len(family.pseudos) != 0
@@ -138,9 +138,9 @@ def test_install_family_folder(run_cli_command, filepath_pseudos):
 
     result = run_cli_command(cmd_install_family, options)
     assert f'installed `{label}`' in result.output
-    assert PseudoPotentialFamily.objects.count() == 1
+    assert PseudoPotentialFamily.collection.count() == 1
 
-    family = PseudoPotentialFamily.objects.get(label=label)
+    family = PseudoPotentialFamily.collection.get(label=label)
     assert family.__class__ is PseudoPotentialFamily
     assert family.description == description
     assert len(family.pseudos) != 0
@@ -175,9 +175,9 @@ def test_install_family_url(run_cli_command, get_pseudo_archive, monkeypatch):
 
     result = run_cli_command(cmd_install_family, options)
     assert f'installed `{label}`' in result.output
-    assert PseudoPotentialFamily.objects.count() == 1
+    assert PseudoPotentialFamily.collection.count() == 1
 
-    family = PseudoPotentialFamily.objects.get(label=label)
+    family = PseudoPotentialFamily.collection.get(label=label)
     assert isinstance(family.pseudos['Ar'], UpfData)
     assert family.__class__ is PseudoPotentialFamily
     assert family.description == description
@@ -239,9 +239,9 @@ def test_install_sssp_monkeypatched(run_monkeypatched_install_sssp):
     options = ['-v', version, '-x', functional, '-p', protocol]
     result = run_monkeypatched_install_sssp(options=options)
     assert f'installed `{label}`' in result.output
-    assert SsspFamily.objects.count() == 1
+    assert SsspFamily.collection.count() == 1
 
-    family = SsspFamily.objects.get(label=label)
+    family = SsspFamily.collection.get(label=label)
     assert family.label == label
 
 
@@ -263,9 +263,9 @@ def test_install_pseudo_dojo_monkeypatched(run_monkeypatched_install_pseudo_dojo
     options = ['-v', version, '-x', functional, '-p', protocol, '-f', pseudo_format]
     result = run_monkeypatched_install_pseudo_dojo(options=options)
     assert f'installed `{label}`' in result.output
-    assert PseudoDojoFamily.objects.count() == 1
+    assert PseudoDojoFamily.collection.count() == 1
 
-    family = PseudoDojoFamily.objects.get(label=label)
+    family = PseudoDojoFamily.collection.get(label=label)
     assert family.label == label
 
 
@@ -275,7 +275,7 @@ def test_install_sssp_download_only(run_monkeypatched_install_sssp):
     options = ['--download-only']
     result = run_monkeypatched_install_sssp(options=options)
 
-    assert SsspFamily.objects.count() == 0
+    assert SsspFamily.collection.count() == 0
     assert 'written to the current directory.' in result.output
 
 
@@ -296,7 +296,7 @@ def test_install_sssp_download_only_exists(run_monkeypatched_install_sssp, get_p
     options = ['--download-only', '-v', version, '-x', functional, '-p', protocol]
     result = run_monkeypatched_install_sssp(options=options)
 
-    assert SsspFamily.objects.count() == 1
+    assert SsspFamily.collection.count() == 1
     assert 'written to the current directory.' in result.output
 
 
@@ -306,7 +306,7 @@ def test_install_pseudo_dojo_download_only(run_monkeypatched_install_pseudo_dojo
     options = ['--download-only']
     result = run_monkeypatched_install_pseudo_dojo(options=options)
 
-    assert PseudoDojoFamily.objects.count() == 0
+    assert PseudoDojoFamily.collection.count() == 0
     assert 'written to the current directory.' in result.output
 
 
@@ -332,5 +332,5 @@ def test_install_pseudo_dojo_download_only_exists(run_monkeypatched_install_pseu
     ]
     result = run_monkeypatched_install_pseudo_dojo(options=options)
 
-    assert PseudoDojoFamily.objects.count() == 1
+    assert PseudoDojoFamily.collection.count() == 1
     assert 'written to the current directory.' in result.output

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -46,7 +46,7 @@ def test_list_filter(clear_db, run_cli_command, get_pseudo_family):
     family_base = get_pseudo_family(label='Pseudo potential family', cls=PseudoPotentialFamily)
     family_sssp = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=SsspFamily, pseudo_type=UpfData)
 
-    assert PseudoPotentialFamily.objects.count() == 2
+    assert PseudoPotentialFamily.collection.count() == 2
 
     result = run_cli_command(cmd_list, ['--raw'])
     assert len(result.output_lines) == 2

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -51,7 +51,7 @@ def test_attempt_sucess(capsys):
         pass
 
     captured = capsys.readouterr()
-    assert captured.out == f'Info: {message} [OK]\n'
+    assert captured.out == f'Report: {message} [OK]\n'
     assert captured.err == ''
 
 
@@ -65,7 +65,7 @@ def test_attempt_exception(capsys):
             raise RuntimeError(exception)
 
     captured = capsys.readouterr()
-    assert captured.out == f'Info: {message} [FAILED]\n'
+    assert captured.out == f'Report: {message} [FAILED]\n'
     assert captured.err == f'Critical: {exception}\n'
 
 
@@ -79,6 +79,6 @@ def test_attempt_exception_traceback(capsys):
             raise RuntimeError(exception)
 
     captured = capsys.readouterr()
-    assert captured.out == f'Info: {message} [FAILED]\n'
+    assert captured.out == f'Report: {message} [FAILED]\n'
     assert captured.err.startswith(f'Critical: {exception}\n')
     assert 'Traceback' in captured.err

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,8 @@ pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=inval
 
 
 @pytest.fixture
-def clear_db(clear_database_before_test):
-    """Alias for the `clear_database_before_test` fixture from `aiida-core`."""
+def clear_db(aiida_profile_clean):
+    """Alias for the `aiida_profile_clean` fixture from `aiida-core`."""
     yield
 
 

--- a/tests/data/pseudo/test_pseudo.py
+++ b/tests/data/pseudo/test_pseudo.py
@@ -53,7 +53,7 @@ def test_constructor_filename(get_pseudo_potential_data, implicit, source_type):
     filepath = pathlib.Path('tempfile.pseudo')
 
     with open(filepath, mode='wb') as handle:
-        handle.write(pseudo.get_object_content(pseudo.filename, mode='rb'))
+        handle.write(pseudo.base.repository.get_object_content(pseudo.filename, mode='rb'))
         handle.flush()
 
     if source_type == 'stream':
@@ -112,7 +112,7 @@ def test_store():
         pseudo.store()
 
     pseudo.element = 'Ar'
-    pseudo.set_attribute(PseudoPotentialData._key_md5, md5_incorrect)  # pylint: disable=protected-access
+    pseudo.base.attributes.set(PseudoPotentialData._key_md5, md5_incorrect)  # pylint: disable=protected-access
 
     with pytest.raises(StoringNotAllowed, match=r'md5 does not match that of stored file:'):
         pseudo.store()
@@ -170,7 +170,7 @@ def test_store_indirect():
     pseudo.element = 'Ar'
 
     node = CalcJobNode()
-    node.add_incoming(pseudo, link_type=LinkType.INPUT_CALC, link_label='pseudo')
+    node.base.links.add_incoming(pseudo, link_type=LinkType.INPUT_CALC, link_label='pseudo')
     node.store_all()
 
 


### PR DESCRIPTION
Dependencies: update requirement `aiida-core~=2.0`

Adds compatibility with AiiDA v2.0. Notable changes:

* Entry points are now loaded through built-in modules instead of the
  custom `reentry`, so `reentry scan` no longer needs to be called.
* Tab-completion now ships with `click` itself, so `click_completion`
  and its manual activiation is removed.
* Update entry points from `aiida-core` by prefixing with `core.`

Also enable the `AIIDA_WARN_v3` environment variable in the `tests` job
of the CI workflow. This will print deprecation warnings from
`aiida-core`. These are also addressed in this commit:

* `Entity.objects` -> `Entity.collection`
* `Node.get_attribute` -> `Node.base.attributes.get`
* `Node.set_attribute` -> `Node.base.attributes.set`
* `Node.get_extra` -> `Node.base.extras.get`
* `Node.set_extra` -> `Node.base.extras.set`
* `Node.get_object_content` -> `Node.base.repository.get_object_content`
* `Node.add_incoming` -> `Node.base.links.add_incoming`

Due to the updated requirements of `click`, the `sphinx-click`
dependency of the `docs` extra also had to be upgraded because the lower
versions had an upper limit on `click`.