### PR TITLE
Docs: remove manual addition of package to `sys.path`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,10 +3,10 @@ version: 2
 python:
     version: 3.8
     install:
-        -   method: pip
-            path: .
-            extra_requirements:
-            -   docs
+    -   method: pip
+        path: .
+        extra_requirements:
+        -   docs
 
 sphinx:
     builder: html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,24 +4,15 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath('../../'))
-
 import aiida_pseudo
 
 # -- Project information -----------------------------------------------------
 
 project = 'aiida-pseudo'
-copyright = '2020-2021, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE (Theory and Simulation of Materials (THEOS) and National Centre for Computational Design and Discovery of Novel Materials (NCCR MARVEL)), Switzerland'
+copyright = """\
+2020-2022, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE (Theory and Simulation of Materials (THEOS) and National Centre
+for Computational Design and Discovery of Novel Materials (NCCR MARVEL)), Switzerland
+"""
 release = aiida_pseudo.__version__
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
The package is installed anyway for the build on ReadTheDocs so we can
simply import it instead of manually adding it to the Python path.