### PR TITLE
CLI: filter cutoffs from JSON file for family cutoffs set

### DIFF
--- a/src/aiida_pseudo/cli/family.py
+++ b/src/aiida_pseudo/cli/family.py
@@ -90,7 +90,9 @@ def cmd_family_cutoffs_set(family, cutoffs, stringency, unit):  # noqa: D301
         try:
             cutoffs_dict[element] = {'cutoff_wfc': values['cutoff_wfc'], 'cutoff_rho': values['cutoff_rho']}
         except KeyError as exception:
-            raise click.BadParameter(f'`{cutoffs.name}` is missing cutoffs for element: {element}') from exception
+            raise click.BadParameter(
+                f'`{cutoffs.name}` is missing cutoffs for element `{element}`: {exception}', param_hint='CUTOFFS'
+            ) from exception
 
     try:
         family.set_cutoffs(cutoffs_dict, stringency, unit=unit)

--- a/src/aiida_pseudo/cli/family.py
+++ b/src/aiida_pseudo/cli/family.py
@@ -85,8 +85,15 @@ def cmd_family_cutoffs_set(family, cutoffs, stringency, unit):  # noqa: D301
     except ValueError as exception:
         raise click.BadParameter(f'`{cutoffs.name}` contains invalid JSON: {exception}', param_hint='CUTOFFS')
 
+    cutoffs_dict = {}
+    for element, values in data.items():
+        try:
+            cutoffs_dict[element] = {'cutoff_wfc': values['cutoff_wfc'], 'cutoff_rho': values['cutoff_rho']}
+        except KeyError as exception:
+            raise click.BadParameter(f'`{cutoffs.name}` is missing cutoffs for element: {element}') from exception
+
     try:
-        family.set_cutoffs(data, stringency, unit=unit)
+        family.set_cutoffs(cutoffs_dict, stringency, unit=unit)
     except ValueError as exception:
         raise click.BadParameter(f'`{cutoffs.name}` contains invalid cutoffs: {exception}', param_hint='CUTOFFS')
 

--- a/tests/cli/test_family.py
+++ b/tests/cli/test_family.py
@@ -37,7 +37,7 @@ def test_family_cutoffs_set(run_cli_command, get_pseudo_family, generate_cutoffs
     high_cutoffs['Ar'].pop('cutoff_wfc')
     filepath.write_text(json.dumps(high_cutoffs))
     result = run_cli_command(cmd_family_cutoffs_set, [family.label, str(filepath), '-s', 'high'], raises=True)
-    assert 'is missing cutoffs for element:' in result.output
+    assert 'Error: Invalid value for CUTOFFS: ' in result.output
     assert sorted(family.get_cutoff_stringencies()) == sorted(['low', 'normal'])
 
     # Set the high stringency
@@ -49,7 +49,7 @@ def test_family_cutoffs_set(run_cli_command, get_pseudo_family, generate_cutoffs
     assert sorted(family.get_cutoff_stringencies()) == sorted(['low', 'normal', 'high'])
     assert family.get_cutoffs(stringency) == cutoffs_dict[stringency]
 
-    # Invalid cutoffs structure - Should pass fine
+    # Additional keys in the cutoffs should be accepted and simply ignored
     stringency = 'invalid'
     high_cutoffs = deepcopy(cutoffs_dict['high'])
     high_cutoffs['Ar']['GME'] = 'moon'


### PR DESCRIPTION
Fixes #93 

Currently the `family cutoffs set` command requires that the JSON file that contains the cutoffs _only_ has the cutoff keys specified for each element. This is because the cutoffs are validated by the `RecommendedCutoffMixin.validate_cutoffs()` method, which doesn't allow for extraneous keys.

However, the  `.json`  file could have been adapted by the user from e.g. the SSSP `metadata.json` or some other dictionary that also contains other keys. As long as the cutoff keys are defined, we shouldn't raise an error just because there are other keys present.

Here we first filter the data loaded from the JSON file for the cutoffs, before passing the dictionary to the `set_cutoffs` method.