### PR TITLE
CLI: add install `--from-download` for sssp and pseudo-dojo

### DIFF
--- a/docs/source/howto.rst
+++ b/docs/source/howto.rst
@@ -28,12 +28,16 @@ Similar to the `SSSP`_ pseudopotential family, the options can be used to set ve
 Moreover, the format of the pseudopotentials can be specified, as well as the default stringency.
 Use ``aiida-pseudo install pseudo-dojo --help`` for more information.
 
+.. note::
+
+    In case you are unable to use these automated commands because of connection issues, please consult the :ref:`troubleshooting section <troubleshooting:automated-fail>`.
+
 .. _how-to:install_archive:
 
 Installing from archive or folder
 =================================
 
-In case the automated install commands fail, or the pseudopotential family you want to use is not supported, you can install the pseudopotential family manually with the following command:
+In case the pseudopotential family you want to use is not supported, you can install the pseudopotential family manually with the following command:
 
 .. code-block:: console
 
@@ -53,7 +57,7 @@ If this fails, you can specify the format manually with the ``--archive-format/-
 
     $ aiida-pseudo install family <ARCHIVE> <LABEL> -f gztar
 
-The valid archive formats are those [defined by the ``shutil.unpack_archive`` function](https://docs.python.org/3/library/shutil.html#shutil.unpack_archive) of the standard Python library.
+The valid archive formats are those defined by the `shutil.unpack_archive <https://docs.python.org/3/library/shutil.html#shutil.unpack_archive>`_ function of the standard Python library.
 
 Pseudopotential format
 ----------------------
@@ -93,6 +97,7 @@ The available pseudopotential family classes can be listed with the command:
 .. important::
 
     The ``pseudo.family.sssp`` and ``pseudo.family.pseudo_dojo`` family types are blacklisted since they have their own :ref:`dedicated install commands <how-to:install_automated>` in ``aiida-pseudo install sssp`` and ``aiida-pseudo install pseudo-dojo``, respectively.
+    In case you are unable to use these commands because of connection issues, please consult the :ref:`troubleshooting section <troubleshooting:automated-fail>`.
 
 Adding recommended cutoffs
 --------------------------

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -5,9 +5,27 @@
 Troubleshooting
 ###############
 
+.. _troubleshooting:automated-fail:
+
 The automated install commands fail
 ===================================
 
 These failures are often due to unstable internet connections causing the download of the pseudopotential archive from the web to fail.
-In this case, it is possible to install the family manually from an archive that is already available on the local file system.
-You can read more on this in the :ref:`how-to section <how-to:install_archive>`.
+In this case, it is possible to download an ``.aiida_pseudo`` archive of the established family, transfer them to the machine where the pseudopotentials need to be installed and install directly from the archive.
+To download the archive, use the ``--download-only`` option:
+
+.. code-block:: console
+
+    $ aiida-pseudo install sssp --download-only
+    Report: downloading patch versions information...  [OK]
+    Report: downloading selected pseudopotentials archive...  [OK]
+    Report: downloading selected pseudopotentials metadata...  [OK]
+    Success: Pseudopotential archive written to: SSSP_1.1_PBE_efficiency.aiida_pseudo
+
+The downloaded archive can be installed through the ``--from-download`` option of the corresponding install command:
+
+.. code-block:: console
+
+    $ aiida-pseudo install sssp --from-download SSSP_1.1_PBE_efficiency.aiida_pseudo
+    Report: unpacking archive and parsing pseudos...  [OK]
+    Success: installed `SSSP/1.1/PBE/efficiency` containing 85 pseudopotentials.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -11,7 +11,7 @@ The automated install commands fail
 ===================================
 
 These failures are often due to unstable internet connections causing the download of the pseudopotential archive from the web to fail.
-In this case, it is possible to download an ``.aiida_pseudo`` archive of the established family, transfer them to the machine where the pseudopotentials need to be installed and install directly from the archive.
+In this case, it is possible to download an ``.aiida_pseudo`` archive of the established family on a machine with a stable internet connection, transfer it to the machine where the pseudopotentials need to be installed and install directly from the archive.
 To download the archive, use the ``--download-only`` option:
 
 .. code-block:: console

--- a/src/aiida_pseudo/cli/install.py
+++ b/src/aiida_pseudo/cli/install.py
@@ -2,8 +2,8 @@
 """Command to install a pseudo potential family."""
 import json
 import pathlib
-import shutil
 import sys
+import tarfile
 import tempfile
 import typing as t
 
@@ -17,7 +17,8 @@ from .params import options, types
 from .root import cmd_root
 
 if t.TYPE_CHECKING:
-    from aiida_pseudo.groups.family import SsspConfiguration
+    from aiida_pseudo.data.pseudo import PseudoPotentialData
+    from aiida_pseudo.groups.family import PseudoDojoConfiguration, PseudoDojoFamily, SsspConfiguration
 
 
 @cmd_root.group('install')
@@ -148,8 +149,138 @@ def download_sssp(
     return patch_version
 
 
+def install_sssp(
+    filepath_archive: pathlib.Path,
+    filepath_metadata: pathlib.Path,
+    label: str,
+    description: str = '',
+    traceback: bool = False
+) -> None:
+    """Install the ``SsspFamily`` and set the recommended cutoffs.
+
+    :param filepath_archive: path to the pseudopotential archive.
+    :param filepath_metadata: path to the metadata file.
+    :param label: label of the pseudopotential family group.
+    :param description: description of the pseudopotential family group.
+    :param traceback: boolean, if true, print the traceback when an exception occurs.
+    """
+    # pylint: disable=too-many-locals
+    from aiida.orm import Group
+
+    from ..groups.family.sssp import SsspFamily
+    from .utils import attempt, create_family_from_archive
+
+    with open(filepath_metadata, 'rb') as handle:
+        handle.seek(0)
+        metadata = json.load(handle)
+
+    with attempt('unpacking archive and parsing pseudos... ', include_traceback=traceback):
+        family = create_family_from_archive(SsspFamily, label, filepath_archive)
+
+    cutoffs = {}
+
+    for element, values in metadata.items():
+        if family.get_pseudo(element).md5 != values['md5']:
+            Group.collection.delete(family.pk)
+            msg = f"md5 of pseudo for element {element} does not match that of the metadata {values['md5']}"
+            echo.echo_critical(msg)
+
+        cutoffs[element] = {'cutoff_wfc': values['cutoff_wfc'], 'cutoff_rho': values['cutoff_rho']}
+
+    family.description = description
+    family.set_cutoffs(cutoffs, 'normal', unit='Ry')
+
+    echo.echo_success(f'installed `{label}` containing {family.count()} pseudopotentials.')
+
+
+@cmd_install.command('sssp')
+@options.VERSION(type=click.Choice(['1.0', '1.1', '1.2', '1.3']), default='1.3', show_default=True)
+@options.FUNCTIONAL(type=click.Choice(['PBE', 'PBEsol']), default='PBE', show_default=True)
+@options.PROTOCOL(type=click.Choice(['efficiency', 'precision']), default='efficiency', show_default=True)
+@options.DOWNLOAD_ONLY()
+@options.FROM_DOWNLOAD()
+@options.TRACEBACK()
+@decorators.with_dbenv()
+def cmd_install_sssp(version, functional, protocol, download_only, from_download, traceback):
+    """Install an SSSP configuration.
+
+    The SSSP configuration will be automatically downloaded from the Materials Cloud Archive entry to create a new
+    `SsspFamily`.
+    """
+    # pylint: disable=too-many-locals, too-many-statements
+    from aiida.common.files import md5_file
+    from aiida.orm import QueryBuilder
+
+    from aiida_pseudo import __version__
+
+    from ..groups.family.sssp import SsspConfiguration, SsspFamily
+
+    if download_only and from_download is not None:
+        raise click.BadParameter(
+            'cannot specify both `--download-only` and `--from-download`.',
+            param_hint="'--download-only' / '--from-download'"
+        )
+
+    configuration = SsspConfiguration(version, functional, protocol)
+
+    if configuration not in SsspFamily.valid_configurations:
+        echo.echo_critical(f'{version} {functional} {protocol} is not a valid SSSP configuration')
+
+    with tempfile.TemporaryDirectory() as dirpath:
+
+        dirpath = pathlib.Path(dirpath)
+
+        filepath_archive = dirpath / 'archive.tar.gz'
+        filepath_metadata = dirpath / 'metadata.json'
+
+        if from_download is not None:
+
+            tarball_path = pathlib.Path(from_download).absolute()
+            with tarfile.open(tarball_path, 'r') as handle:
+                handle.extractall(dirpath)
+
+            filepath_configuration = dirpath / 'configuration.json'
+
+            with filepath_configuration.open('r') as handle:
+                configuration = SsspConfiguration(**json.load(handle))
+        else:
+            download_sssp(configuration, filepath_archive, filepath_metadata, traceback)
+
+        label = SsspFamily.format_configuration_label(configuration)
+
+        if not download_only and QueryBuilder().append(SsspFamily, filters={'label': label}).first():
+            echo.echo_report(f'{SsspFamily.__name__}<{label}> is already installed')
+            sys.exit(1)
+
+        if download_only:
+            filepath_configuration = dirpath / 'configuration.json'
+
+            with filepath_configuration.open('w') as handle:
+                handle.write(json.dumps(configuration._asdict()))
+
+            tarball_path = pathlib.Path.cwd() / f'{label}.aiida_pseudo'.replace('/', '_')
+
+            if tarball_path.exists():
+                echo.echo_critical(f'the file `{tarball_path}` already exists.')
+
+            with tarfile.open(tarball_path, 'w') as tarball_file:
+                for filepath in [filepath_configuration, filepath_metadata, filepath_archive]:
+                    tarball_file.add(filepath, filepath.name)
+            echo.echo_success(f'Pseudopotential archive written to: {tarball_path.name}')
+            return
+
+        description = (
+            f'SSSP v{configuration.version} {configuration.functional} {configuration.protocol} '
+            f'installed with aiida-pseudo v{__version__}'
+        )
+        description += f'\nArchive pseudos md5: {md5_file(filepath_archive)}'
+        description += f'\nPseudo metadata md5: {md5_file(filepath_metadata)}'
+
+        install_sssp(filepath_archive, filepath_metadata, label, description, traceback)
+
+
 def download_pseudo_dojo(
-    configuration: 'SsspConfiguration',
+    configuration: 'PseudoDojoConfiguration',
     filepath_archive: pathlib.Path,
     filepath_metadata: pathlib.Path,
     traceback: bool = False
@@ -161,8 +292,7 @@ def download_pseudo_dojo(
     :param filepath_metadata: absolute filepath to write the metadata archive to.
     :param traceback: boolean, if true, print the traceback when an exception occurs.
     """
-    from aiida_pseudo.groups.family import PseudoDojoFamily
-
+    from ..groups.family.pseudo_dojo import PseudoDojoFamily
     from .utils import attempt
 
     label = PseudoDojoFamily.format_configuration_label(configuration)
@@ -184,118 +314,41 @@ def download_pseudo_dojo(
             handle.flush()
 
 
-@cmd_install.command('sssp')
-@options.VERSION(type=click.Choice(['1.0', '1.1', '1.2', '1.3']), default='1.3', show_default=True)
-@options.FUNCTIONAL(type=click.Choice(['PBE', 'PBEsol']), default='PBE', show_default=True)
-@options.PROTOCOL(type=click.Choice(['efficiency', 'precision']), default='efficiency', show_default=True)
-@options.DOWNLOAD_ONLY()
-@options.TRACEBACK()
-@decorators.with_dbenv()
-def cmd_install_sssp(version, functional, protocol, download_only, traceback):
-    """Install an SSSP configuration.
+def install_pseudo_dojo(
+    configuration: 'PseudoDojoConfiguration',
+    filepath_archive: pathlib.Path,
+    filepath_metadata: pathlib.Path,
+    pseudo_type: 'PseudoPotentialData',
+    label: str,
+    description: str = '',
+    traceback: bool = False
+) -> 'PseudoDojoFamily':
+    """Install the ``PseudoDojoFamily`` and set the recommended cutoffs.
 
-    The SSSP configuration will be automatically downloaded from the Materials Cloud Archive entry to create a new
-    `SsspFamily`.
+    :param filepath_archive: path to the pseudopotential archive.
+    :param filepath_metadata: path to the metadata file.
+    :param label: label of the pseudopotential family group.
+    :pseudo_type: type of the pseudopotentials (psp8, upf, ...).
+    :param description: description of the pseudopotential family group.
+    :param traceback: boolean, if true, print the traceback when an exception occurs.
     """
     # pylint: disable=too-many-locals
-    from aiida.common.files import md5_file
-    from aiida.orm import Group, QueryBuilder
+    from aiida.orm import Group
 
-    from aiida_pseudo import __version__
-    from aiida_pseudo.groups.family import SsspConfiguration, SsspFamily
-
+    from ..groups.family.pseudo_dojo import PseudoDojoConfiguration, PseudoDojoFamily
     from .utils import attempt, create_family_from_archive
 
-    configuration = SsspConfiguration(version, functional, protocol)
-    label = SsspFamily.format_configuration_label(configuration)
+    with attempt('unpacking archive and parsing pseudos... ', include_traceback=traceback):
+        family = create_family_from_archive(PseudoDojoFamily, label, filepath_archive, pseudo_type=pseudo_type)
 
-    if configuration not in SsspFamily.valid_configurations:
-        echo.echo_critical(f'{configuration} is not a valid configuration.')
+    with attempt('unpacking metadata archive and parsing metadata...', include_traceback=traceback):
+        md5s, cutoffs = PseudoDojoFamily.parse_djrepos_from_archive(filepath_metadata, pseudo_type=pseudo_type)
 
-    if not download_only and QueryBuilder().append(SsspFamily, filters={'label': label}).first():
-        echo.echo_report(f'{SsspFamily.__name__}<{label}> is already installed')
-        sys.exit(1)
-
-    with tempfile.TemporaryDirectory() as dirpath:
-
-        dirpath = pathlib.Path(dirpath)
-        filepath_archive = dirpath / 'archive.tar.gz'
-        filepath_metadata = dirpath / 'metadata.json'
-
-        patch_version = download_sssp(configuration, filepath_archive, filepath_metadata, traceback)
-
-        description = f'SSSP v{patch_version} {functional} {protocol} installed with aiida-pseudo v{__version__}'
-        description += f'\nArchive pseudos md5: {md5_file(filepath_archive)}'
-        description += f'\nPseudo metadata md5: {md5_file(filepath_metadata)}'
-
-        if download_only:
-            for filepath in [filepath_archive, filepath_metadata]:
-                filepath_target = pathlib.Path.cwd() / filepath.name
-                if filepath_target.exists():
-                    echo.echo_warning(f'the file `{filepath_target}` already exists, skipping.')
-                else:
-                    # Cannot use ``pathlib.Path.rename`` because this will fail if it moves across file systems.
-                    shutil.move(filepath, filepath_target)
-                    echo.echo_success(f'`{filepath_target.name}` written to the current directory.')
-            return
-
-        with open(filepath_metadata, 'rb') as handle:
-            handle.seek(0)
-            metadata = json.load(handle)
-
-        with attempt('unpacking archive and parsing pseudos... ', include_traceback=traceback):
-            family = create_family_from_archive(SsspFamily, label, filepath_archive)
-
-        cutoffs = {}
-
-        for element, values in metadata.items():
-            if family.get_pseudo(element).md5 != values['md5']:
-                Group.collection.delete(family.pk)
-                msg = f"md5 of pseudo for element {element} does not match that of the metadata {values['md5']}"
-                echo.echo_critical(msg)
-
-            cutoffs[element] = {'cutoff_wfc': values['cutoff_wfc'], 'cutoff_rho': values['cutoff_rho']}
-
-        family.description = description
-        family.set_cutoffs(cutoffs, 'normal', unit='Ry')
-
-        echo.echo_success(f'installed `{label}` containing {family.count()} pseudopotentials.')
-
-
-@cmd_install.command('pseudo-dojo')
-@options.VERSION(type=click.Choice(['0.4', '0.5', '1.0']), default='0.4', show_default=True)
-@options.FUNCTIONAL(type=click.Choice(['PBE', 'PBEsol', 'LDA']), default='PBE', show_default=True)
-@options.RELATIVISTIC(type=click.Choice(['SR', 'SR3plus', 'FR']), default='SR', show_default=True)
-@options.PROTOCOL(type=click.Choice(['standard', 'stringent']), default='standard', show_default=True)
-@options.PSEUDO_FORMAT(type=click.Choice(['psp8', 'upf', 'psml', 'jthxml']), default='psp8', show_default=True)
-@options.DEFAULT_STRINGENCY(type=click.Choice(['low', 'normal', 'high']), default='normal', show_default=True)
-@options.DOWNLOAD_ONLY()
-@options.TRACEBACK()
-@decorators.with_dbenv()
-def cmd_install_pseudo_dojo(
-    version, functional, relativistic, protocol, pseudo_format, default_stringency, download_only, traceback
-):
-    """Install a PseudoDojo configuration.
-
-    The PseudoDojo configuration will be automatically downloaded from pseudo-dojo.org to create a new
-    `PseudoDojoFamily` subclass instance based on the specified pseudopotential format.
-    """
-    # pylint: disable=too-many-locals,too-many-arguments,too-many-branches,too-many-statements
-    from aiida.common.files import md5_file
-    from aiida.orm import Group, QueryBuilder
-
-    from aiida_pseudo import __version__
-    from aiida_pseudo.data.pseudo import JthXmlData, PsmlData, Psp8Data, UpfData
-    from aiida_pseudo.groups.family import PseudoDojoConfiguration, PseudoDojoFamily
-
-    from .utils import attempt, create_family_from_archive
-
-    pseudo_type_mapping = {
-        'jthxml': JthXmlData,
-        'psp8': Psp8Data,
-        'psml': PsmlData,
-        'upf': UpfData,
-    }
+    for element, md5 in md5s.items():
+        if family.get_pseudo(element).md5 != md5:
+            Group.collection.delete(family.pk)
+            msg = f'md5 of pseudo for element {element} does not match that of the metadata {md5}'
+            echo.echo_critical(msg)
 
     # yapf: disable
     paw_configurations = (
@@ -306,6 +359,79 @@ def cmd_install_pseudo_dojo(
     )
     # yapf: enable
 
+    # The PAW configurations have missing cutoffs for the Lanthanides, which have ben replaced with a placeholder
+    # value of `-1`. We replace these with the 1.5 * the maximum cutoff from the same stringency so that these
+    # potentials are still usable, but this should be taken as a _rough_ approximation.
+    # We check only the `cutoff_wfc` because `cutoff_rho` is not provided by PseudoDojo and is therefore
+    # locally calculated in `PseudoDojoFamily.parse_djrepos_from_archive` as `2.0 * cutoff_wfc` for PAW.
+    if configuration in paw_configurations:
+        adjusted_cutoffs = {}
+        for stringency, str_cutoffs in cutoffs.items():
+            adjusted_cutoffs[stringency] = []
+            max_cutoff_wfc = max(cutoffs['cutoff_wfc'] for cutoffs in str_cutoffs.values())
+            filler_cutoff_wfc = max_cutoff_wfc * 1.5
+            for element, cutoff in str_cutoffs.items():
+                if cutoff['cutoff_wfc'] <= 0:
+                    cutoffs[stringency][element]['cutoff_wfc'] = filler_cutoff_wfc
+                    cutoffs[stringency][element]['cutoff_rho'] = 2.0 * filler_cutoff_wfc
+                    adjusted_cutoffs[stringency].append(element)
+
+        for stringency, elements in adjusted_cutoffs.items():
+            msg = f'stringency `{stringency}` has missing recommended cutoffs for elements ' \
+                f'{", ".join(elements)}: as a substitute, 1.5 * the maximum cutoff of the stringency ' \
+                'was set for these elements. USE WITH CAUTION!'
+            echo.echo_warning(msg)
+
+    family.description = description
+    for stringency, cutoff_values in cutoffs.items():
+        family.set_cutoffs(cutoff_values, stringency, unit='Eh')
+
+    echo.echo_success(f'installed `{label}` containing {family.count()} pseudopotentials.')
+
+    return family
+
+
+@cmd_install.command('pseudo-dojo')
+@options.VERSION(type=click.Choice(['0.4', '0.5', '1.0']), default='0.4', show_default=True)
+@options.FUNCTIONAL(type=click.Choice(['PBE', 'PBEsol', 'LDA']), default='PBE', show_default=True)
+@options.RELATIVISTIC(type=click.Choice(['SR', 'SR3plus', 'FR']), default='SR', show_default=True)
+@options.PROTOCOL(type=click.Choice(['standard', 'stringent']), default='standard', show_default=True)
+@options.PSEUDO_FORMAT(type=click.Choice(['psp8', 'upf', 'psml', 'jthxml']), default='psp8', show_default=True)
+@options.DEFAULT_STRINGENCY(type=click.Choice(['low', 'normal', 'high']), default='normal', show_default=True)
+@options.DOWNLOAD_ONLY()
+@options.FROM_DOWNLOAD()
+@options.TRACEBACK()
+@decorators.with_dbenv()
+def cmd_install_pseudo_dojo(
+    version, functional, relativistic, protocol, pseudo_format, default_stringency, download_only, from_download,
+    traceback
+):
+    """Install a PseudoDojo configuration.
+
+    The PseudoDojo configuration will be automatically downloaded from pseudo-dojo.org to create a new
+    `PseudoDojoFamily` subclass instance based on the specified pseudopotential format.
+    """
+    # pylint: disable=too-many-locals,too-many-arguments,too-many-branches,too-many-statements
+    from aiida.common.files import md5_file
+    from aiida.orm import QueryBuilder
+
+    from aiida_pseudo import __version__
+    from aiida_pseudo.data.pseudo import JthXmlData, PsmlData, Psp8Data, UpfData
+    from aiida_pseudo.groups.family.pseudo_dojo import PseudoDojoConfiguration, PseudoDojoFamily
+
+    if download_only and from_download is not None:
+        raise click.BadParameter(
+            'cannot specify both `--download-only` and `--from-download`.',
+            param_hint="'--download-only' / '--from-download'"
+        )
+
+    pseudo_type_mapping = {
+        'jthxml': JthXmlData,
+        'psp8': Psp8Data,
+        'psml': PsmlData,
+        'upf': UpfData,
+    }
+
     try:
         pseudo_type = pseudo_type_mapping[pseudo_format]
     except KeyError:
@@ -313,75 +439,58 @@ def cmd_install_pseudo_dojo(
 
     configuration = PseudoDojoConfiguration(version, functional, relativistic, protocol, pseudo_format)
     label = PseudoDojoFamily.format_configuration_label(configuration)
-    description = f'{configuration} installed with aiida-pseudo v{__version__}'
 
     if configuration not in PseudoDojoFamily.valid_configurations:
         echo.echo_critical(f'{configuration} is not a valid configuration')
 
-    if not download_only and QueryBuilder().append(PseudoDojoFamily, filters={'label': label}).first():
-        echo.echo_report(f'{PseudoDojoFamily.__name__}<{label}> is already installed.')
-        sys.exit(1)
-
     with tempfile.TemporaryDirectory() as dirpath:
 
         dirpath = pathlib.Path(dirpath)
+
         filepath_archive = dirpath / 'archive.tgz'
         filepath_metadata = dirpath / 'metadata.tgz'
 
-        download_pseudo_dojo(configuration, filepath_archive, filepath_metadata, traceback)
+        if from_download is not None:
 
+            tarball_path = pathlib.Path(from_download).absolute()
+            with tarfile.open(tarball_path, 'r') as handle:
+                handle.extractall(dirpath)
+
+            filepath_configuration = dirpath / 'configuration.json'
+
+            with filepath_configuration.open('r') as handle:
+                configuration = PseudoDojoConfiguration(**json.load(handle))
+                pseudo_type = pseudo_type_mapping[configuration.pseudo_format]
+        else:
+            download_pseudo_dojo(configuration, filepath_archive, filepath_metadata, traceback)
+
+        label = PseudoDojoFamily.format_configuration_label(configuration)
+
+        if not download_only and QueryBuilder().append(PseudoDojoFamily, filters={'label': label}).first():
+            echo.echo_report(f'{PseudoDojoFamily.__name__}<{label}> is already installed')
+            sys.exit(1)
+
+        if download_only:
+            filepath_configuration = dirpath / 'configuration.json'
+
+            with filepath_configuration.open('w') as handle:
+                handle.write(json.dumps(configuration._asdict()))
+
+            tarball_path = pathlib.Path.cwd() / f'{label}.aiida_pseudo'.replace('/', '_')
+
+            if tarball_path.exists():
+                echo.echo_critical(f'the file `{tarball_path}` already exists.')
+
+            with tarfile.open(tarball_path, 'w') as tarball_file:
+                for filepath in [filepath_configuration, filepath_metadata, filepath_archive]:
+                    tarball_file.add(filepath, filepath.name)
+            echo.echo_success(f'Pseudopotential archive written to: {tarball_path.name}')
+            return
+
+        description = f'{configuration} installed with aiida-pseudo v{__version__}'
         description += f'\nArchive pseudos md5: {md5_file(filepath_archive)}'
         description += f'\nPseudo metadata md5: {md5_file(filepath_metadata)}'
 
-        if download_only:
-            for filepath in [filepath_archive, filepath_metadata]:
-                filepath_target = pathlib.Path.cwd() / filepath.name
-                if filepath_target.exists():
-                    echo.echo_warning(f'the file `{filepath_target}` already exists, skipping.')
-                else:
-                    # Cannot use ``pathlib.Path.rename`` because this will fail if it moves across file systems.
-                    shutil.move(filepath, filepath_target)
-                    echo.echo_success(f'`{filepath_target.name}` written to the current directory.')
-            return
-
-        with attempt('unpacking archive and parsing pseudos... ', include_traceback=traceback):
-            family = create_family_from_archive(PseudoDojoFamily, label, filepath_archive, pseudo_type=pseudo_type)
-
-        with attempt('unpacking metadata archive and parsing metadata...', include_traceback=traceback):
-            md5s, cutoffs = PseudoDojoFamily.parse_djrepos_from_archive(filepath_metadata, pseudo_type=pseudo_type)
-
-        for element, md5 in md5s.items():
-            if family.get_pseudo(element).md5 != md5:
-                Group.collection.delete(family.pk)
-                msg = f'md5 of pseudo for element {element} does not match that of the metadata {md5}'
-                echo.echo_critical(msg)
-
-        # The PAW configurations have missing cutoffs for the Lanthanides, which have ben replaced with a placeholder
-        # value of `-1`. We replace these with the 1.5 * the maximum cutoff from the same stringency so that these
-        # potentials are still usable, but this should be taken as a _rough_ approximation.
-        # We check only the `cutoff_wfc` because `cutoff_rho` is not provided by PseudoDojo and is therefore
-        # locally calculated in `PseudoDojoFamily.parse_djrepos_from_archive` as `2.0 * cutoff_wfc` for PAW.
-        if configuration in paw_configurations:
-            adjusted_cutoffs = {}
-            for stringency, str_cutoffs in cutoffs.items():
-                adjusted_cutoffs[stringency] = []
-                max_cutoff_wfc = max(cutoffs['cutoff_wfc'] for cutoffs in str_cutoffs.values())
-                filler_cutoff_wfc = max_cutoff_wfc * 1.5
-                for element, cutoff in str_cutoffs.items():
-                    if cutoff['cutoff_wfc'] <= 0:
-                        cutoffs[stringency][element]['cutoff_wfc'] = filler_cutoff_wfc
-                        cutoffs[stringency][element]['cutoff_rho'] = 2.0 * filler_cutoff_wfc
-                        adjusted_cutoffs[stringency].append(element)
-
-            for stringency, elements in adjusted_cutoffs.items():
-                msg = f'stringency `{stringency}` has missing recommended cutoffs for elements ' \
-                    f'{", ".join(elements)}: as a substitute, 1.5 * the maximum cutoff of the stringency ' \
-                    'was set for these elements. USE WITH CAUTION!'
-                echo.echo_warning(msg)
-
-        family.description = description
-        for stringency, cutoff_values in cutoffs.items():
-            family.set_cutoffs(cutoff_values, stringency, unit='Eh')
-        family.set_default_stringency(default_stringency)
-
-        echo.echo_success(f'installed `{label}` containing {family.count()} pseudopotentials.')
+        install_pseudo_dojo(
+            configuration, filepath_archive, filepath_metadata, pseudo_type, label, description, traceback
+        ).set_default_stringency(default_stringency)

--- a/src/aiida_pseudo/cli/install.py
+++ b/src/aiida_pseudo/cli/install.py
@@ -270,12 +270,13 @@ def cmd_install_sssp(version, functional, protocol, download_only, from_download
 
             if configuration not in SsspFamily.valid_configurations:
                 echo.echo_critical(f'{version} {functional} {protocol} is not a valid SSSP configuration')
-        else:
-            download_sssp(configuration, filepath_archive, filepath_metadata, traceback)
 
         if QueryBuilder().append(SsspFamily, filters={'label': label}).first():
             echo.echo_report(f'{SsspFamily.__name__}<{label}> is already installed')
             sys.exit(1)
+
+        if not from_download:
+            download_sssp(configuration, filepath_archive, filepath_metadata, traceback)
 
         description = (
             f'SSSP v{configuration.version} {configuration.functional} {configuration.protocol} '
@@ -489,12 +490,13 @@ def cmd_install_pseudo_dojo(
 
             if configuration not in PseudoDojoFamily.valid_configurations:
                 echo.echo_critical(f'{configuration} is not a valid configuration')
-        else:
-            download_pseudo_dojo(configuration, filepath_archive, filepath_metadata, traceback)
 
         if QueryBuilder().append(PseudoDojoFamily, filters={'label': label}).first():
             echo.echo_report(f'{PseudoDojoFamily.__name__}<{label}> is already installed')
             sys.exit(1)
+
+        if not from_download:
+            download_pseudo_dojo(configuration, filepath_archive, filepath_metadata, traceback)
 
         description = f'{configuration} installed with aiida-pseudo v{__version__}'
         description += f'\nArchive pseudos md5: {md5_file(filepath_archive)}'

--- a/src/aiida_pseudo/cli/params/options.py
+++ b/src/aiida_pseudo/cli/params/options.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Reusable options for CLI commands."""
 import functools
+from pathlib import Path
 import shutil
 
 from aiida.cmdline.params import options as core_options
@@ -113,4 +114,13 @@ DOWNLOAD_ONLY = core_options.OverridableOption(
         'Only download the pseudopotential files to the current working directory, without installing the '
         'pseudopotential family.'
     )
+)
+
+FROM_DOWNLOAD = core_options.OverridableOption(
+    '--from-download',
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=False,
+    default=None,
+    show_default=False,
+    help='Install the pseudpotential family from the archive and metadata downloaded with the `--download-only` option.'
 )

--- a/src/aiida_pseudo/cli/params/options.py
+++ b/src/aiida_pseudo/cli/params/options.py
@@ -120,7 +120,5 @@ FROM_DOWNLOAD = core_options.OverridableOption(
     '--from-download',
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     required=False,
-    default=None,
-    show_default=False,
     help='Install the pseudpotential family from the archive and metadata downloaded with the `--download-only` option.'
 )

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -277,7 +277,7 @@ def test_install_sssp_download_only(run_monkeypatched_install_sssp):
     result = run_monkeypatched_install_sssp(options=options)
 
     assert SsspFamily.collection.count() == 0
-    assert 'written to the current directory.' in result.output
+    assert 'Success: Pseudopotential archive written to:' in result.output
 
 
 @pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
@@ -298,7 +298,25 @@ def test_install_sssp_download_only_exists(run_monkeypatched_install_sssp, get_p
     result = run_monkeypatched_install_sssp(options=options)
 
     assert SsspFamily.collection.count() == 1
-    assert 'written to the current directory.' in result.output
+    assert 'Success: Pseudopotential archive written to:' in result.output
+
+
+@pytest.mark.parametrize('configuration', SsspFamily.valid_configurations)
+@pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
+def test_install_sssp_from_download(run_monkeypatched_install_sssp, configuration):
+    """Test the ``aiida-pseudo install sssp`` command with the ``--from-download`` option."""
+    options = [
+        '--download-only', '-v', configuration.version, '-x', configuration.functional, '-p', configuration.protocol
+    ]
+    result = run_monkeypatched_install_sssp(options=options)
+
+    label = SsspFamily.format_configuration_label(configuration).replace('/', '_')
+    filepath = pathlib.Path.cwd() / f'{label}.aiida_pseudo'
+    options = ['--from-download', str(filepath)]
+
+    result = run_monkeypatched_install_sssp(options=options)
+    assert SsspFamily.collection.count() == 1
+    assert 'Success: installed `SSSP/' in result.output
 
 
 @pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
@@ -308,7 +326,7 @@ def test_install_pseudo_dojo_download_only(run_monkeypatched_install_pseudo_dojo
     result = run_monkeypatched_install_pseudo_dojo(options=options)
 
     assert PseudoDojoFamily.collection.count() == 0
-    assert 'written to the current directory.' in result.output
+    assert 'Success: Pseudopotential archive written to:' in result.output
 
 
 @pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
@@ -334,4 +352,27 @@ def test_install_pseudo_dojo_download_only_exists(run_monkeypatched_install_pseu
     result = run_monkeypatched_install_pseudo_dojo(options=options)
 
     assert PseudoDojoFamily.collection.count() == 1
-    assert 'written to the current directory.' in result.output
+    assert 'Success: Pseudopotential archive written to:' in result.output
+
+
+@pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
+def test_install_pseudo_dojo_from_download(run_monkeypatched_install_pseudo_dojo):
+    """Test the ``aiida-pseudo install pseudo-dojo`` command with the ``--from-download`` option."""
+    version = '1.0'
+    functional = 'LDA'
+    relativistic = 'SR'
+    protocol = 'stringent'
+    pseudo_format = 'jthxml'
+    configuration = PseudoDojoConfiguration(version, functional, relativistic, protocol, pseudo_format)
+    options = [
+        '--download-only', '-v', version, '-x', functional, '-r', relativistic, '-p', protocol, '-f', pseudo_format
+    ]
+    result = run_monkeypatched_install_pseudo_dojo(options=options)
+
+    label = PseudoDojoFamily.format_configuration_label(configuration).replace('/', '_')
+    filepath = pathlib.Path.cwd() / f'{label}.aiida_pseudo'
+    options = ['--from-download', str(filepath)]
+
+    result = run_monkeypatched_install_pseudo_dojo(options=options)
+    assert PseudoDojoFamily.collection.count() == 1
+    assert 'Success: installed `PseudoDojo' in result.output

--- a/tests/groups/family/test_pseudo.py
+++ b/tests/groups/family/test_pseudo.py
@@ -153,7 +153,7 @@ def test_create_from_folder_duplicate_element(tmp_path, filepath_pseudos):
     dirpath = tmp_path / 'pseudos'
     shutil.copytree(filepath_pseudos(), dirpath)
 
-    (dirpath / 'Ar.UPF').touch()
+    (dirpath / 'Ar.upf_duplicate').touch()
 
     with pytest.raises(ValueError, match=r'directory `.*` contains pseudo potentials with duplicate elements'):
         PseudoPotentialFamily.create_from_folder(dirpath, 'label')


### PR DESCRIPTION
Fixes #92 

Our workaround for installing an "established" family like a `SsspFamily` or `PseudoDojoFamily` required using the `install family` command, but this is explicitly forbidden since we do not want the user to be able to install an arbitrary set of pseudopotentials as one of these classes. This means there is currently no way to install the archive and metadata obtained with the `--download-only` option of the automated install commands as a proper `SsspFamily` or `PseudoDojoFamily`.

Here, we add the `--from-download` option to the automated install commands to allow the user to install the downloaded pseudopotentials and set the recommended cutoffs automatically for an `SsspFamily` or `PseudoDojoFamily`. The `--download-only` option now also produces a single `.aiida_pseudo` archive that contains:

* The archive containing the pseudos
* The corresponding metadata
* The configuration in JSON format

The user can pass such an archive to the `from-download` option to install the corresponding pseudopotential family.