### PR TITLE
CLI: update to be compatible with `aiida-core==2.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 keywords = ['aiida', 'pseudopotentials']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core~=2.0',
+    'aiida-core~=2.1',
     'click~=8.0',
     'pint~=0.16.1',
     'requests~=2.20',

--- a/src/aiida_pseudo/cli/params/options.py
+++ b/src/aiida_pseudo/cli/params/options.py
@@ -1,22 +1,33 @@
 # -*- coding: utf-8 -*-
 """Reusable options for CLI commands."""
+import functools
 import shutil
 
-from aiida.cmdline.params.options import OverridableOption
+from aiida.cmdline.params import options as core_options
+from aiida.cmdline.params import types as core_types
 import click
 
 from .types import PseudoPotentialFamilyTypeParam, PseudoPotentialTypeParam, UnitParamType
 
 __all__ = (
-    'VERSION', 'FUNCTIONAL', 'RELATIVISTIC', 'PROTOCOL', 'PSEUDO_FORMAT', 'STRINGENCY', 'DEFAULT_STRINGENCY',
-    'TRACEBACK', 'FAMILY_TYPE', 'ARCHIVE_FORMAT', 'UNIT', 'DOWNLOAD_ONLY'
+    'PROFILE', 'VERBOSITY', 'VERSION', 'FUNCTIONAL', 'RELATIVISTIC', 'PROTOCOL', 'PSEUDO_FORMAT', 'STRINGENCY',
+    'DEFAULT_STRINGENCY', 'TRACEBACK', 'FAMILY_TYPE', 'ARCHIVE_FORMAT', 'UNIT', 'DOWNLOAD_ONLY'
 )
 
-VERSION = OverridableOption(
+PROFILE = functools.partial(
+    core_options.PROFILE, type=core_types.ProfileParamType(load_profile=True), expose_value=False
+)
+
+# Clone the ``VERBOSITY`` option from ``aiida-core`` so the ``-v`` short flag can be removed, since that overlaps with
+# the flag of the ``VERSION`` option of this CLI.
+VERBOSITY = core_options.VERBOSITY.clone()
+VERBOSITY.args = ('--verbosity',)
+
+VERSION = core_options.OverridableOption(
     '-v', '--version', type=click.STRING, required=False, help='Select the version of the installed configuration.'
 )
 
-FUNCTIONAL = OverridableOption(
+FUNCTIONAL = core_options.OverridableOption(
     '-x',
     '--functional',
     type=click.STRING,
@@ -24,7 +35,7 @@ FUNCTIONAL = OverridableOption(
     help='Select the functional of the installed configuration.'
 )
 
-RELATIVISTIC = OverridableOption(
+RELATIVISTIC = core_options.OverridableOption(
     '-r',
     '--relativistic',
     type=click.STRING,
@@ -32,11 +43,11 @@ RELATIVISTIC = OverridableOption(
     help='Select the type of relativistic effects included in the installed configuration.'
 )
 
-PROTOCOL = OverridableOption(
+PROTOCOL = core_options.OverridableOption(
     '-p', '--protocol', type=click.STRING, required=False, help='Select the protocol of the installed configuration.'
 )
 
-PSEUDO_FORMAT = OverridableOption(
+PSEUDO_FORMAT = core_options.OverridableOption(
     '-f',
     '--pseudo-format',
     type=click.STRING,
@@ -44,11 +55,11 @@ PSEUDO_FORMAT = OverridableOption(
     help='Select the pseudopotential file format of the installed configuration.'
 )
 
-STRINGENCY = OverridableOption(
+STRINGENCY = core_options.OverridableOption(
     '-s', '--stringency', type=click.STRING, required=False, help='Stringency level for the recommended cutoffs.'
 )
 
-DEFAULT_STRINGENCY = OverridableOption(
+DEFAULT_STRINGENCY = core_options.OverridableOption(
     '-s',
     '--default-stringency',
     type=click.STRING,
@@ -56,11 +67,11 @@ DEFAULT_STRINGENCY = OverridableOption(
     help='Select the default stringency level for the installed configuration.'
 )
 
-TRACEBACK = OverridableOption(
+TRACEBACK = core_options.OverridableOption(
     '-t', '--traceback', is_flag=True, help='Include the stacktrace if an exception is encountered.'
 )
 
-FAMILY_TYPE = OverridableOption(
+FAMILY_TYPE = core_options.OverridableOption(
     '-F',
     '--family-type',
     type=PseudoPotentialFamilyTypeParam(),
@@ -69,7 +80,7 @@ FAMILY_TYPE = OverridableOption(
     help='Choose the type of pseudo potential family to create.'
 )
 
-PSEUDO_TYPE = OverridableOption(
+PSEUDO_TYPE = core_options.OverridableOption(
     '-P',
     '--pseudo-type',
     type=PseudoPotentialTypeParam(),
@@ -81,11 +92,11 @@ PSEUDO_TYPE = OverridableOption(
     )
 )
 
-ARCHIVE_FORMAT = OverridableOption(
+ARCHIVE_FORMAT = core_options.OverridableOption(
     '-f', '--archive-format', type=click.Choice([fmt[0] for fmt in shutil.get_archive_formats()])
 )
 
-UNIT = OverridableOption(
+UNIT = core_options.OverridableOption(
     '-u',
     '--unit',
     type=UnitParamType(quantity='energy'),
@@ -95,7 +106,7 @@ UNIT = OverridableOption(
     help='Specify the energy unit of the cutoffs. Must be recognized by the ``UnitRegistry`` of the ``pint`` library.'
 )
 
-DOWNLOAD_ONLY = OverridableOption(
+DOWNLOAD_ONLY = core_options.OverridableOption(
     '--download-only',
     is_flag=True,
     help=(

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -1,12 +1,47 @@
 # -*- coding: utf-8 -*-
-"""Test the root command of the CLI."""
+"""Tests for CLI commands."""
+from __future__ import annotations
+
+import subprocess
+
+import click
+import pytest
+
 from aiida_pseudo.cli import cmd_root
 
 
-def test_root(run_cli_command):
-    """Test the root command for the CLI is callable."""
-    run_cli_command(cmd_root)
+def recurse_commands(command: click.Command, parents: list[str] = None):
+    """Recursively return all subcommands that are part of ``command``.
 
-    for option in ['-h', '--help']:
-        result = run_cli_command(cmd_root, [option])
-        assert cmd_root.__doc__ in result.output
+    :param command: The click command to start with.
+    :param parents: A list of strings that represent the parent commands leading up to the current command.
+    :returns: A list of strings denoting the full path to the current command.
+    """
+    if isinstance(command, click.Group):
+        for command_name in command.commands:
+            subcommand = command.get_command(None, command_name)
+            if parents is not None:
+                subparents = parents + [command.name]
+            else:
+                subparents = [command.name]
+            yield from recurse_commands(subcommand, subparents)
+
+    if parents is not None:
+        yield parents + [command.name]
+    else:
+        yield [command.name]
+
+
+@pytest.mark.parametrize('command', recurse_commands(cmd_root))
+@pytest.mark.parametrize('help_option', ('--help', '-h'))
+def test_commands_help_option(command, help_option):
+    """Test the help options for all subcommands of the CLI.
+
+    The usage of ``subprocess.run`` is on purpose because using :meth:`click.Context.invoke`, which is used by the
+    ``run_cli_command`` fixture that should usually be used in testing CLI commands, does not behave exactly the same
+    compared to a direct invocation on the command line. The invocation through ``invoke`` does not go through all the
+    parent commands and so might not get all the necessary initializations.
+    """
+    result = subprocess.run(command + [help_option], check=False, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert 'Usage:' in result.stdout


### PR DESCRIPTION
Fixes #130 

Currently the CLI is broken with `aiida-core==2.1`. The reason is that we are using the `PROFILE` option, which relies on the command that it is attached to configure certain things, such as the context. In v2.1, the behavior was changed causing the commands to except because the `PROFILE` option cannot find certain attributes it expects in the context.

For the `PROFILE` option to work, the root command should use the class `aiida.cmdline.groups.VerdiCommandGroup` as its `cls`. This class defines a custom context class that is necessary. It also automatically provides the verbosity option for all subcommands, so the explicit declaration can now be removed.

The problem was not detected in the unit tests because they only show up when the root command is invoked. The unit tests call the subcommands directly though, and this circumvents the root command. This is documented behavior of `click` and there is no way around it. The only solution is to call the commands through the command  line interface exactly as they would be called normally.

This is now done in the `test_commands.py` file. The test parametrizes over all existing (sub)commands and directly calls it as a subprocess. This guarantees that the root command is called including its specific context that needs to be setup.