### PR TITLE
DevOps: Update dependency `pylint==2.15.5`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ docs = [
 ]
 pre-commit = [
     'pre-commit~=2.2',
-    'pylint==2.13.7',
+    'pylint==2.15.5',
     'pylint-aiida~=0.1',
 ]
 tests = [
@@ -105,7 +105,6 @@ max-line-length = 120
 
 [tool.pylint.messages_control]
 disable = [
-    'bad-continuation',
     'duplicate-code',
     'import-outside-toplevel',
     'too-many-arguments',

--- a/src/aiida_pseudo/cli/install.py
+++ b/src/aiida_pseudo/cli/install.py
@@ -112,7 +112,7 @@ def download_sssp(
     # releases of the SSSP only contain bug fixes, there is no reason to have the user install an outdated patch
     # version. So, the latest patch version of the minor version that is specified by the user is always installed.
     with attempt('downloading patch versions information... ', include_traceback=traceback):
-        response = requests.get(url_template.format(filename='versions.yaml'))
+        response = requests.get(url_template.format(filename='versions.yaml'), timeout=30)
         response.raise_for_status()
         # The `version_mapping` is a dictionary that maps each minor version (key) to the latest patch version (value)
         version_mapping = yaml.load(response.content, Loader=yaml.SafeLoader)
@@ -127,14 +127,14 @@ def download_sssp(
     url_metadata = url_template.format(filename=metadata_filename)
 
     with attempt('downloading selected pseudopotentials archive... ', include_traceback=traceback):
-        response = requests.get(url_archive)
+        response = requests.get(url_archive, timeout=30)
         response.raise_for_status()
         with open(filepath_archive, 'wb') as handle:
             handle.write(response.content)
             handle.flush()
 
     with attempt('downloading selected pseudopotentials metadata... ', include_traceback=traceback):
-        response = requests.get(url_metadata)
+        response = requests.get(url_metadata, timeout=30)
         response.raise_for_status()
         with open(filepath_metadata, 'wb') as handle:
             handle.write(response.content)
@@ -165,14 +165,14 @@ def download_pseudo_dojo(
     url_metadata = PseudoDojoFamily.get_url_metadata(label)
 
     with attempt('downloading selected pseudopotentials archive... ', include_traceback=traceback):
-        response = requests.get(url_archive)
+        response = requests.get(url_archive, timeout=30)
         response.raise_for_status()
         with open(filepath_archive, 'wb') as handle:
             handle.write(response.content)
             handle.flush()
 
     with attempt('downloading selected pseudopotentials metadata archive... ', include_traceback=traceback):
-        response = requests.get(url_metadata)
+        response = requests.get(url_metadata, timeout=30)
         response.raise_for_status()
         with open(filepath_metadata, 'wb') as handle:
             handle.write(response.content)
@@ -358,7 +358,7 @@ def cmd_install_pseudo_dojo(
             adjusted_cutoffs = {}
             for stringency, str_cutoffs in cutoffs.items():
                 adjusted_cutoffs[stringency] = []
-                max_cutoff_wfc = max([cutoffs['cutoff_wfc'] for cutoffs in str_cutoffs.values()])
+                max_cutoff_wfc = max(cutoffs['cutoff_wfc'] for cutoffs in str_cutoffs.values())
                 filler_cutoff_wfc = max_cutoff_wfc * 1.5
                 for element, cutoff in str_cutoffs.items():
                     if cutoff['cutoff_wfc'] <= 0:

--- a/src/aiida_pseudo/cli/params/types.py
+++ b/src/aiida_pseudo/cli/params/types.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=no-self-use
 """Custom parameter types for command line interface commands."""
 from __future__ import annotations
 
@@ -152,7 +151,7 @@ class PathOrUrl(click.Path):
             return pathlib.Path(super().convert(value, param, ctx))
         except click.exceptions.BadParameter:
             with attempt(f'attempting to download data from `{value}`...'):
-                response = requests.get(value)
+                response = requests.get(value, timeout=30)
                 response.raise_for_status()
                 return response
 


### PR DESCRIPTION
The following changes were necessary

 * The `bad-continuation` was removed by `pylint`
 * The `no-self-use` warning was moved to a plugin
 * The `requests.get` methods need a timeout. It is set to 30 seconds for all calls. This should be largely sufficient. Note that the timeout is not a time limit on the entire response download; rather, an exception is raised if the server has not issued a response for timeout seconds, i.e., if no bytes have been received on the underlying socket for timeout seconds