### PR TITLE
CLI: Reduce the load time significantly

### DIFF
--- a/src/aiida_pseudo/cli/family.py
+++ b/src/aiida_pseudo/cli/family.py
@@ -6,7 +6,6 @@ from aiida.cmdline.params import options as options_core
 from aiida.cmdline.utils import decorators, echo
 import click
 
-from ..groups.mixins import RecommendedCutoffMixin
 from .params import arguments, options, types
 from .root import cmd_root
 
@@ -25,6 +24,8 @@ def cmd_family():
 def cmd_family_show(family, stringency, unit, raw):
     """Show details of pseudo potential family."""
     from tabulate import tabulate
+
+    from ..groups.mixins import RecommendedCutoffMixin
 
     if isinstance(family, RecommendedCutoffMixin):
 
@@ -79,6 +80,8 @@ def cmd_family_cutoffs_set(family, cutoffs, stringency, unit):  # noqa: D301
 
     where the cutoffs are expected to be in electronvolt by default.
     """
+    from ..groups.mixins import RecommendedCutoffMixin
+
     if not isinstance(family, RecommendedCutoffMixin):
         raise click.BadParameter(f'family `{family}` does not support recommended cutoffs to be set.')
 

--- a/src/aiida_pseudo/cli/install.py
+++ b/src/aiida_pseudo/cli/install.py
@@ -4,6 +4,7 @@ import json
 import pathlib
 import shutil
 import tempfile
+import typing as t
 
 from aiida.cmdline.params import options as options_core
 from aiida.cmdline.utils import decorators, echo
@@ -11,10 +12,11 @@ import click
 import requests
 import yaml
 
-from aiida_pseudo.groups.family import PseudoDojoConfiguration, SsspConfiguration
-
 from .params import options, types
 from .root import cmd_root
+
+if t.TYPE_CHECKING:
+    from aiida_pseudo.groups.family import SsspConfiguration
 
 
 @cmd_root.group('install')
@@ -89,7 +91,7 @@ def cmd_install_family(archive, label, description, archive_format, family_type,
 
 
 def download_sssp(
-    configuration: SsspConfiguration,
+    configuration: 'SsspConfiguration',
     filepath_archive: pathlib.Path,
     filepath_metadata: pathlib.Path,
     traceback: bool = False
@@ -144,7 +146,7 @@ def download_sssp(
 
 
 def download_pseudo_dojo(
-    configuration: SsspConfiguration,
+    configuration: 'SsspConfiguration',
     filepath_archive: pathlib.Path,
     filepath_metadata: pathlib.Path,
     traceback: bool = False
@@ -197,7 +199,7 @@ def cmd_install_sssp(version, functional, protocol, download_only, traceback):
     from aiida.orm import Group, QueryBuilder
 
     from aiida_pseudo import __version__
-    from aiida_pseudo.groups.family import SsspFamily
+    from aiida_pseudo.groups.family import SsspConfiguration, SsspFamily
 
     from .utils import attempt, create_family_from_archive
 
@@ -280,7 +282,7 @@ def cmd_install_pseudo_dojo(
 
     from aiida_pseudo import __version__
     from aiida_pseudo.data.pseudo import JthXmlData, PsmlData, Psp8Data, UpfData
-    from aiida_pseudo.groups.family import PseudoDojoFamily
+    from aiida_pseudo.groups.family import PseudoDojoConfiguration, PseudoDojoFamily
 
     from .utils import attempt, create_family_from_archive
 

--- a/src/aiida_pseudo/cli/params/types.py
+++ b/src/aiida_pseudo/cli/params/types.py
@@ -8,7 +8,6 @@ from aiida.cmdline.params.types import GroupParamType
 import click
 import requests
 
-from ...common.units import U
 from ..utils import attempt
 
 __all__ = ('PseudoPotentialFamilyTypeParam', 'PseudoPotentialFamilyParam', 'PseudoPotentialTypeParam')
@@ -174,6 +173,8 @@ class UnitParamType(click.ParamType):
 
         :raises: ``click.BadParameter`` if the provided unit is not valid for the quantity defined for this instance.
         """
+        from ...common.units import U
+
         if value not in U:
             raise click.BadParameter(f'`{value}` is not a valid unit.')
 


### PR DESCRIPTION
Fixes #141 

Some of the commands imported a number of resources at the top of the modules that have large loading times on first import. This was causing the load time of the CLI to be ~1.5 seconds, even when just rendering the help message.

By moving the slow packages inside the commands themselves, the load time is reduced to a mere ~0.2 seconds. This makes the CLI much more snappy to use, especially when using tab-completion.