### PR TITLE
`RecommendedCutoffMixin`: Remove workaround for stringency units

### DIFF
--- a/src/aiida_pseudo/groups/mixins/cutoffs.py
+++ b/src/aiida_pseudo/groups/mixins/cutoffs.py
@@ -216,7 +216,7 @@ class RecommendedCutoffMixin:
         cutoffs_dict.pop(stringency)
 
         cutoffs_unit_dict = self._get_cutoffs_unit_dict()
-        cutoffs_unit_dict.pop(stringency, None)  # `None` is added to support pseudo families installed with v0.5.0
+        cutoffs_unit_dict.pop(stringency)
 
         self.base.extras.set(self._key_cutoffs, cutoffs_dict)
         self.base.extras.set(self._key_cutoffs_unit, cutoffs_unit_dict)
@@ -261,16 +261,7 @@ class RecommendedCutoffMixin:
         """
         self.validate_stringency(stringency)
         stringency = stringency or self.get_default_stringency()
-
-        try:
-            return self._get_cutoffs_unit_dict()[stringency]
-        except KeyError:
-            # Workaround to deal with pseudo families installed in v0.5.0 - Set default unit in case it is not in extras
-            cutoffs_unit_dict = self._get_cutoffs_unit_dict()
-            cutoffs_unit_dict[stringency] = 'eV'
-            self.base.extras.set(self._key_cutoffs_unit, cutoffs_unit_dict)
-            return 'eV'
-            # End of workaround
+        return self._get_cutoffs_unit_dict()[stringency]
 
     def get_recommended_cutoffs(self, *, elements=None, structure=None, stringency=None, unit=None):
         """Return tuple of recommended wavefunction and density cutoffs for the given elements or ``StructureData``.


### PR DESCRIPTION
Fixes #76 

A workaround was added in `v0.6` for families with recommended cutoffs that were installed with `v0.5` since that older version didn't explicitly store the units of the stringencies in the extras which the new API assumed would always be there.

The workaround would account for the lack of this extra and would automatically introduce it (in a sense migrating the old family to be compatible with the new API) the first time it would be requested.

Almost two years has passed since the release of `v0.6` which should have been plenty for existing families to have been migrated through this workaround and so it can now be removed.