### PR TITLE
DevOps: Update Python version and `setup-python` action in CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,10 +16,10 @@ jobs:
         -   name: Checkout source
             uses: actions/checkout@v2
 
-        -   name: Set up Python 3.9
-            uses: actions/setup-python@v2
+        -   name: Install Python 3.10
+            uses: actions/setup-python@v4
             with:
-                python-version: '3.9'
+                python-version: '3.10'
 
         -   name: Validate the tag version against the package version
             run: python .github/workflows/validate_release_tag.py $GITHUB_REF
@@ -32,20 +32,14 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            uses: actions/cache@v1
+        -   name: Install Python
+            uses: actions/setup-python@v4
             with:
-                path: ~/.cache/pip
-                key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-pre-commit-
+                python-version: '3.10'
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
-        -   name: Set up Python
-            uses: actions/setup-python@v2
-            with:
-                python-version: '3.9'
-
-        -   name: Install Python dependencies
+        -   name: Install Python package and dependencies
             run: pip install -e .[pre-commit,tests]
 
         -   name: Run pre-commit
@@ -71,20 +65,14 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-${{ matrix.python-version }}-tests
-
-        -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v2
+        -   name: Install Python ${{ matrix.python-version }}
+            uses: actions/setup-python@v4
             with:
                 python-version: ${{ matrix.python-version }}
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
-        -   name: Install Python dependencies
+        -   name: Install Python package and dependencies
             run: pip install -e .[tests]
 
         -   name: Run pytest
@@ -100,10 +88,10 @@ jobs:
         -   name: Checkout source
             uses: actions/checkout@v2
 
-        -   name: Set up Python 3.9
-            uses: actions/setup-python@v2
+        -   name: Install Python 3.10
+            uses: actions/setup-python@v4
             with:
-                python-version: '3.9'
+                python-version: '3.10'
 
         -   name: Install flit
             run: pip install flit~=3.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,14 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            uses: actions/cache@v1
+        -   name: Install Python
+            uses: actions/setup-python@v4
             with:
-                path: ~/.cache/pip
-                key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-pre-commit-
+                python-version: '3.10'
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
-        -   name: Set up Python
-            uses: actions/setup-python@v2
-            with:
-                python-version: '3.9'
-
-        -   name: Install Python dependencies
+        -   name: Install Python package and dependencies
             run: pip install -e .[pre-commit,tests]
 
         -   name: Run pre-commit
@@ -50,20 +44,14 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-${{ matrix.python-version }}-tests
-
-        -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v2
+        -   name: Install Python ${{ matrix.python-version }}
+            uses: actions/setup-python@v4
             with:
                 python-version: ${{ matrix.python-version }}
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
-        -   name: Install Python dependencies
+        -   name: Install Python package and dependencies
             run: pip install -e .[tests]
 
         -   name: Run pytest

--- a/.github/workflows/validate_release_tag.py
+++ b/.github/workflows/validate_release_tag.py
@@ -28,8 +28,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('GITHUB_REF', help='The GITHUB_REF environmental variable')
     args = parser.parse_args()
-    assert args.GITHUB_REF.startswith('refs/tags/v'), f'GITHUB_REF should start with "refs/tags/v": {args.GITHUB_REF}'
-    tag_version = args.GITHUB_REF[11:]
+    TAG_PREFIX = 'refs/tags/v'
+    assert args.GITHUB_REF.startswith(TAG_PREFIX), f'GITHUB_REF should start with "{TAG_PREFIX}": {args.GITHUB_REF}'
+    tag_version = args.GITHUB_REF.removeprefix(TAG_PREFIX)
     package_version = get_version_from_module(Path('src/aiida_pseudo/__init__.py').read_text(encoding='utf-8'))
     error_message = f'The tag version `{tag_version}` is different from the package version `{package_version}`'
     assert tag_version == package_version, error_message

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: flynt
 
 -   repo: https://github.com/pycqa/isort
-    rev: '5.10.1'
+    rev: '5.12.0'
     hooks:
     -   id: isort
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+    os: ubuntu-22.04
+    tools:
+        python: '3.11'
+
 python:
-    version: 3.8
     install:
     -   method: pip
         path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ autoapi_ignore = ['*cli*']
 
 # Settings for the `sphinx.ext.intersphinx` extension
 intersphinx_mapping = {
-    'aiida': ('http://aiida_core.readthedocs.io/en/latest/', None),
+    'aiida': ('http://aiida-core.readthedocs.io/en/latest/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
The `setup-python` action is updated to `v4` which comes with built-in support for caching of the `pip` install step, so the `cache` action can be dropped.

The default version of Python for non-matrix based jobs is updated to 3.10 which allows to use the more robust `removeprefix` string method in the `validate_release_tag.py` file. This is more readable than the previous string slicing.