### PR TITLE
Devops: Make use of the improved fixtures in `aiida-core`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,14 +54,6 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
-    services:
-      postgres:
-        image: postgres:12
-      rabbitmq:
-        image: rabbitmq:latest
-        ports:
-        - 5672:5672
-
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,6 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
-    services:
-      postgres:
-        image: postgres:12
-      rabbitmq:
-        image: rabbitmq:latest
-        ports:
-        - 5672:5672
-
     steps:
     - uses: actions/checkout@v2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   'Programming Language :: Python :: 3.12'
 ]
 dependencies = [
-  'aiida-core~=2.1',
+  'aiida-core~=2.6',
   'click~=8.0',
   'pint~=0.23.0',
   'requests~=2.20'
@@ -46,7 +46,6 @@ requires-python = '>=3.9'
 
 [project.optional-dependencies]
 dev = [
-  'pgtest~=1.3',
   'pre-commit~=2.2',
   'pytest>=6.0'
 ]

--- a/src/aiida_pseudo/data/pseudo/pseudo.py
+++ b/src/aiida_pseudo/data/pseudo/pseudo.py
@@ -17,9 +17,9 @@ __all__ = ('PseudoPotentialData',)
 class PseudoPotentialDataCaching(NodeCaching):
     """Class to define caching behavior of ``PseudoPotentialData`` nodes."""
 
-    def get_objects_to_hash(self) -> list:
+    def get_objects_to_hash(self) -> dict[str, str]:
         """Return a list of objects which should be included in the node hash."""
-        return [self._node.element, self._node.md5]
+        return {'element': self._node.element, 'md5': self._node.md5}
 
 
 class PseudoPotentialData(plugins.DataFactory('core.singlefile')):

--- a/tests/cli/test_family.py
+++ b/tests/cli/test_family.py
@@ -12,7 +12,7 @@ from aiida_pseudo.groups.family.sssp import SsspFamily
 from numpy.testing import assert_almost_equal
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_family_cutoffs_set(run_cli_command, get_pseudo_family, generate_cutoffs_dict, tmp_path):
     """Test the `aiida-pseudo family cutoffs set` command."""
     family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
@@ -60,7 +60,7 @@ def test_family_cutoffs_set(run_cli_command, get_pseudo_family, generate_cutoffs
     assert family.get_cutoffs(stringency) == cutoffs_dict['high']
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_family_cutoffs_set_unit(run_cli_command, get_pseudo_family, generate_cutoffs, tmp_path):
     """Test the `aiida-pseudo family cutoffs set` command with the ``--unit`` flag."""
     family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
@@ -97,7 +97,7 @@ def test_family_cutoffs_set_unit(run_cli_command, get_pseudo_family, generate_cu
     'family_cls,label',
     [(SsspFamily, 'SSSP/1.1/PBE/efficiency'), (PseudoDojoFamily, 'PseudoDojo/0.4/PBE/SR/standard/psp8')],
 )
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_family_cutoffs_set_established(
     run_cli_command, get_pseudo_family, generate_cutoffs, tmp_path, family_cls, label
 ):
@@ -117,7 +117,7 @@ def test_family_cutoffs_set_established(
     assert f"Invalid value for 'FAMILY': The value `{family}` is not allowed for this parameter." in result.output
 
 
-def test_family_show(clear_db, run_cli_command, get_pseudo_family):
+def test_family_show(aiida_profile_clean, run_cli_command, get_pseudo_family):
     """Test the `aiida-pseudo show` command."""
     family = get_pseudo_family()
     result = run_cli_command(cmd_family_show, [family.label])
@@ -127,7 +127,9 @@ def test_family_show(clear_db, run_cli_command, get_pseudo_family):
         assert node.filename in result.output
 
 
-def test_family_show_recommended_cutoffs(clear_db, run_cli_command, get_pseudo_family, generate_cutoffs_dict):
+def test_family_show_recommended_cutoffs(
+    aiida_profile_clean, run_cli_command, get_pseudo_family, generate_cutoffs_dict
+):
     """Test the `aiida-pseudo show` command for a family with recommended cutoffs."""
     family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
     stringencies = ('normal', 'high')
@@ -157,7 +159,7 @@ def test_family_show_recommended_cutoffs(clear_db, run_cli_command, get_pseudo_f
             assert_almost_equal(cutoffs[1], float(fields[4]))
 
 
-def test_family_show_argument_type(clear_db, run_cli_command, get_pseudo_family):
+def test_family_show_argument_type(aiida_profile_clean, run_cli_command, get_pseudo_family):
     """Test that `aiida-pseudo show` only accepts instances of `PseudoPotentialFamily` or subclasses as argument."""
     pseudo_family = get_pseudo_family(label='pseudo-family', cls=PseudoPotentialFamily)
     normal_group = Group('normal-group').store()
@@ -166,7 +168,7 @@ def test_family_show_argument_type(clear_db, run_cli_command, get_pseudo_family)
     run_cli_command(cmd_family_show, [normal_group.label], raises=SystemExit)
 
 
-def test_family_show_raw(clear_db, run_cli_command, get_pseudo_family):
+def test_family_show_raw(aiida_profile_clean, run_cli_command, get_pseudo_family):
     """Test the `-r/--raw` option."""
     family = get_pseudo_family()
 
@@ -175,7 +177,7 @@ def test_family_show_raw(clear_db, run_cli_command, get_pseudo_family):
         assert len(result.output_lines) == len(family.nodes)
 
 
-def test_family_show_unit_default(clear_db, run_cli_command, get_pseudo_family):
+def test_family_show_unit_default(aiida_profile_clean, run_cli_command, get_pseudo_family):
     """Test the `family show` command with default unit."""
     elements = ['Ar', 'Kr']
     cutoff_dict = {'normal': {'Ar': {'cutoff_wfc': 50, 'cutoff_rho': 200}, 'Kr': {'cutoff_wfc': 25, 'cutoff_rho': 100}}}
@@ -199,7 +201,7 @@ def test_family_show_unit_default(clear_db, run_cli_command, get_pseudo_family):
 
 
 @pytest.mark.parametrize('unit', ['Ry', 'eV', 'hartree', 'aJ'])
-def test_family_show_unit(clear_db, run_cli_command, get_pseudo_family, unit):
+def test_family_show_unit(aiida_profile_clean, run_cli_command, get_pseudo_family, unit):
     """Test the `-u/--unit` option."""
     elements = [
         'Ar',

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -147,7 +147,7 @@ def run_monkeypatched_install_pseudo_dojo(run_cli_command, filepath_pseudos, mon
     return _run_monkeypatched_install_pseudo_dojo
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_install_family(run_cli_command, get_pseudo_archive):
     """Test ``aiida-pseudo install family``."""
     label = 'family'
@@ -165,7 +165,7 @@ def test_install_family(run_cli_command, get_pseudo_archive):
     assert len(family.pseudos) != 0
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_install_family_folder(run_cli_command, filepath_pseudos):
     """Test ``aiida-pseudo install family` from folder`."""
     label = 'family_test'
@@ -183,7 +183,7 @@ def test_install_family_folder(run_cli_command, filepath_pseudos):
     assert len(family.pseudos) != 0
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_install_family_url(run_cli_command, get_pseudo_archive, monkeypatch):
     """Test ``aiida-pseudo install family`` when installing from a URL.
 
@@ -222,7 +222,7 @@ def test_install_family_url(run_cli_command, get_pseudo_archive, monkeypatch):
     assert len(family.pseudos) != 0
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_install_sssp(run_cli_command):
     """Test the ``aiida-pseudo install sssp`` command."""
     from aiida_pseudo import __version__
@@ -241,7 +241,7 @@ def test_install_sssp(run_cli_command):
     assert 'is already installed' in result.output
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_install_pseudo_dojo(run_cli_command):
     """Test the ``aiida-pseudo install pseudo-dojo`` command."""
     from aiida_pseudo import __version__
@@ -260,7 +260,7 @@ def test_install_pseudo_dojo(run_cli_command):
     assert 'is already installed' in result.output
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_install_sssp_monkeypatched(run_monkeypatched_install_sssp):
     """Test the ``aiida-pseudo install sssp`` command with a monkeypatched download function.
 
@@ -283,7 +283,7 @@ def test_install_sssp_monkeypatched(run_monkeypatched_install_sssp):
     assert family.label == label
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.filterwarnings('ignore:filename .* does not have a supported extension.:UserWarning')
 def test_install_pseudo_dojo_monkeypatched(run_monkeypatched_install_pseudo_dojo):
     """Test the ``aiida-pseudo install pseudo-dojo`` command with a monkeypatched download function.
@@ -308,7 +308,7 @@ def test_install_pseudo_dojo_monkeypatched(run_monkeypatched_install_pseudo_dojo
     assert family.label == label
 
 
-@pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
+@pytest.mark.usefixtures('aiida_profile_clean', 'chdir_tmp_path')
 def test_install_sssp_download_only(run_monkeypatched_install_sssp):
     """Test the ``aiida-pseudo install sssp`` command with the ``--download-only`` option.
 
@@ -328,7 +328,7 @@ def test_install_sssp_download_only(run_monkeypatched_install_sssp):
     assert 'Success: Pseudopotential archive written to:' in result.output
 
 
-@pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
+@pytest.mark.usefixtures('aiida_profile_clean', 'chdir_tmp_path')
 def test_install_sssp_download_only_exists(run_monkeypatched_install_sssp, get_pseudo_family):
     """Test the ``aiida-pseudo install sssp`` command with the ``--download-only`` option.
 
@@ -350,7 +350,7 @@ def test_install_sssp_download_only_exists(run_monkeypatched_install_sssp, get_p
 
 
 @pytest.mark.parametrize('configuration', SsspFamily.valid_configurations)
-@pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
+@pytest.mark.usefixtures('aiida_profile_clean', 'chdir_tmp_path')
 def test_install_sssp_from_download(run_monkeypatched_install_sssp, configuration):
     """Test the ``aiida-pseudo install sssp`` command with the ``--from-download`` option."""
     options = [
@@ -373,7 +373,7 @@ def test_install_sssp_from_download(run_monkeypatched_install_sssp, configuratio
     assert 'Success: installed `SSSP/' in result.output
 
 
-@pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
+@pytest.mark.usefixtures('aiida_profile_clean', 'chdir_tmp_path')
 def test_install_pseudo_dojo_download_only(run_monkeypatched_install_pseudo_dojo):
     """Test the ``aiida-pseudo install pseudo-dojo`` command with the ``--download-only`` option.
 
@@ -393,7 +393,7 @@ def test_install_pseudo_dojo_download_only(run_monkeypatched_install_pseudo_dojo
     assert 'Success: Pseudopotential archive written to:' in result.output
 
 
-@pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
+@pytest.mark.usefixtures('aiida_profile_clean', 'chdir_tmp_path')
 def test_install_pseudo_dojo_download_only_exists(run_monkeypatched_install_pseudo_dojo, get_pseudo_family):
     """Test the ``aiida-pseudo install pseudo_dojo`` command with the ``--download-only`` option.
 
@@ -429,7 +429,7 @@ def test_install_pseudo_dojo_download_only_exists(run_monkeypatched_install_pseu
     assert 'Success: Pseudopotential archive written to:' in result.output
 
 
-@pytest.mark.usefixtures('clear_db', 'chdir_tmp_path')
+@pytest.mark.usefixtures('aiida_profile_clean', 'chdir_tmp_path')
 def test_install_pseudo_dojo_from_download(run_monkeypatched_install_pseudo_dojo):
     """Test the ``aiida-pseudo install pseudo-dojo`` command with the ``--from-download`` option."""
     version = '1.0'

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -5,7 +5,7 @@ from aiida_pseudo.data.pseudo import UpfData
 from aiida_pseudo.groups.family import PseudoPotentialFamily, SsspFamily
 
 
-def test_list(clear_db, run_cli_command, get_pseudo_family):
+def test_list(aiida_profile_clean, run_cli_command, get_pseudo_family):
     """Test the `aiida-pseudo list` command."""
     result = run_cli_command(cmd_list)
     assert 'no pseudo potential families have been installed yet: use `aiida-pseudo install`.' in result.output
@@ -17,7 +17,7 @@ def test_list(clear_db, run_cli_command, get_pseudo_family):
     assert family.label in result.output
 
 
-def test_list_raw(clear_db, run_cli_command, get_pseudo_family):
+def test_list_raw(aiida_profile_clean, run_cli_command, get_pseudo_family):
     """Test the `-r/--raw` option."""
     get_pseudo_family()
 
@@ -26,7 +26,7 @@ def test_list_raw(clear_db, run_cli_command, get_pseudo_family):
         assert len(result.output_lines) == 1
 
 
-def test_list_project(clear_db, run_cli_command, get_pseudo_family):
+def test_list_project(aiida_profile_clean, run_cli_command, get_pseudo_family):
     """Test the `-p/--project` option."""
     family = get_pseudo_family()
 
@@ -39,7 +39,7 @@ def test_list_project(clear_db, run_cli_command, get_pseudo_family):
     assert family.label in result.output
 
 
-def test_list_filter(clear_db, run_cli_command, get_pseudo_family):
+def test_list_filter(aiida_profile_clean, run_cli_command, get_pseudo_family):
     """Test the filtering option `-F`."""
     family_base = get_pseudo_family(label='Pseudo potential family', cls=PseudoPotentialFamily)
     family_sssp = get_pseudo_family(label='SSSP/1.0/PBE/efficiency', cls=SsspFamily, pseudo_type=UpfData)
@@ -57,7 +57,7 @@ def test_list_filter(clear_db, run_cli_command, get_pseudo_family):
     assert family_sssp.label in result.output
 
 
-def test_list_filter_no_result(clear_db, run_cli_command, get_pseudo_family):
+def test_list_filter_no_result(aiida_profile_clean, run_cli_command, get_pseudo_family):
     """Test the filtering option `-F` for a type for which no families exist."""
     get_pseudo_family(label='Pseudo potential family', cls=PseudoPotentialFamily)
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -8,7 +8,7 @@ from aiida_pseudo.cli.utils import attempt, create_family_from_archive
 from aiida_pseudo.groups.family import PseudoPotentialFamily
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize(('fmt',), [(fmt[0],) for fmt in shutil.get_archive_formats()])
 def test_create_family_from_archive(get_pseudo_archive, fmt):
     """Test the `create_family_from_archive` utility function."""
@@ -21,14 +21,14 @@ def test_create_family_from_archive(get_pseudo_archive, fmt):
     assert family.count() != 0
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_family_from_archive_incorrect_filetype(tmp_path):
     """Test the `create_family_from_archive` utility function for incorrect archive filetype."""
     with pytest.raises(OSError, match=r'failed to unpack the archive.*'):
         create_family_from_archive(PseudoPotentialFamily, 'label', tmp_path)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_family_from_archive_incorrect_format(tmp_path):
     """Test the `create_family_from_archive` utility function for invalid archive content."""
     with tempfile.NamedTemporaryFile(suffix='.tar.gz') as filepath_archive:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,7 @@ from aiida.plugins import DataFactory
 from aiida_pseudo.data.pseudo import PseudoPotentialData
 from aiida_pseudo.groups.family import CutoffsPseudoPotentialFamily, PseudoPotentialFamily
 
-pytest_plugins = ['aiida.manage.tests.pytest_fixtures']
-
-
-@pytest.fixture
-def clear_db(aiida_profile_clean):
-    """Alias for the `aiida_profile_clean` fixture from `aiida-core`."""
-    yield
+pytest_plugins = 'aiida.tools.pytest_fixtures'
 
 
 @pytest.fixture

--- a/tests/data/pseudo/test_jthxml.py
+++ b/tests/data/pseudo/test_jthxml.py
@@ -39,7 +39,7 @@ def test_constructor(filepath_pseudos):
             assert pseudo.element == filepath.name.split('.')[0]
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_file(filepath_pseudos, get_pseudo_potential_data):
     """Test the `JthXmlData.set_file` method.
 

--- a/tests/data/pseudo/test_pseudo.py
+++ b/tests/data/pseudo/test_pseudo.py
@@ -98,7 +98,7 @@ def test_prepare_source(source):
         assert PseudoPotentialData.prepare_source(source) is source
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_store():
     """Test the `PseudoPotentialData.store` method."""
     stream = io.BytesIO(b'pseudo')
@@ -123,7 +123,7 @@ def test_store():
     assert pseudo.is_stored
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_element():
     """Test the `PseudoPotentialData.element` property."""
     element = 'Ar'
@@ -143,7 +143,7 @@ def test_element():
         pseudo.element = element
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_md5():
     """Test the `PseudoPotentialData.md5` property."""
     stream = io.BytesIO(b'pseudo')
@@ -163,7 +163,7 @@ def test_md5():
         pseudo.md5 = md5
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_store_indirect():
     """Test the `PseudoPotentialData.store` method when called indirectly because its is an input."""
     pseudo = PseudoPotentialData(io.BytesIO(b'pseudo'))
@@ -174,7 +174,7 @@ def test_store_indirect():
     node.store_all()
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_or_create(get_pseudo_potential_data):
     """Test the ``PseudoPotentialData.get_or_create`` classmethod."""
     upf = get_pseudo_potential_data(entry_point='upf')

--- a/tests/data/pseudo/test_psf.py
+++ b/tests/data/pseudo/test_psf.py
@@ -56,7 +56,7 @@ def test_constructor(filepath_pseudos):
             assert pseudo.element == filepath.name.split('.')[0]
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_file(filepath_pseudos, get_pseudo_potential_data):
     """Test the `PsfData.set_file` method.
 

--- a/tests/data/pseudo/test_psml.py
+++ b/tests/data/pseudo/test_psml.py
@@ -39,7 +39,7 @@ def test_constructor(filepath_pseudos):
             assert pseudo.element == filepath.name.split('.')[0]
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_file(filepath_pseudos, get_pseudo_potential_data):
     """Test the `PsmlData.set_file` method.
 

--- a/tests/data/pseudo/test_psp8.py
+++ b/tests/data/pseudo/test_psp8.py
@@ -39,7 +39,7 @@ def test_constructor(filepath_pseudos):
             assert pseudo.element == filepath.name.split('.')[0]
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_file(filepath_pseudos, get_pseudo_potential_data):
     """Test the `Psp8Data.set_file` method.
 

--- a/tests/data/pseudo/test_upf.py
+++ b/tests/data/pseudo/test_upf.py
@@ -40,7 +40,7 @@ def test_constructor(filepath_pseudos):
             assert pseudo.element == filepath.name.split('.')[0]
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_file(filepath_pseudos, get_pseudo_potential_data):
     """Test the `UpfData.set_file` method.
 

--- a/tests/data/pseudo/test_vps.py
+++ b/tests/data/pseudo/test_vps.py
@@ -40,7 +40,7 @@ def test_constructor(filepath_pseudos):
             assert pseudo.element == filepath.name.split('.')[0]
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_file(filepath_pseudos, get_pseudo_potential_data):
     """Test the `VpsData.set_file` method.
 

--- a/tests/groups/family/test_pseudo.py
+++ b/tests/groups/family/test_pseudo.py
@@ -32,7 +32,7 @@ def test_pseudo_types_validation(pseudo_types):
         CustomFamily(label='custom')
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_pseudo_type(get_pseudo_potential_data):
     """Test ``PseudoPotentialFamily.pseudo_type`` property."""
     family = PseudoPotentialFamily(label='label').store()
@@ -52,7 +52,7 @@ def test_pseudo_type(get_pseudo_potential_data):
     assert family.pseudo_type is None
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_construct():
     """Test the construction of `PseudoPotentialFamily` works."""
     label = 'label'
@@ -70,7 +70,7 @@ def test_construct():
     assert family.description == description
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder(filepath_pseudos):
     """Test the `PseudoPotentialFamily.create_from_folder` class method."""
     label = 'label'
@@ -81,7 +81,7 @@ def test_create_from_folder(filepath_pseudos):
     assert len(family.nodes) == len(list(filepath_pseudos().iterdir()))
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder_nested(filepath_pseudos, tmp_path):
     """Test the `PseudoPotentialFamily.create_from_folder` class method when the pseudos are in a subfolder."""
     shutil.copytree(filepath_pseudos(), tmp_path / 'subdirectory')
@@ -94,7 +94,7 @@ def test_create_from_folder_nested(filepath_pseudos, tmp_path):
     assert len(family.nodes) == len(list(filepath_pseudos().iterdir()))
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('deduplicate', (True, False))
 def test_create_from_folder_deduplicate(filepath_pseudos, deduplicate):
     """Test the `PseudoPotentialFamily.create_from_folder` class method."""
@@ -123,7 +123,7 @@ def test_create_from_folder_deduplicate(filepath_pseudos, deduplicate):
         assert not original_pseudos.intersection(family_pseudos)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder_parse_fail(tmp_path):
     """Test the `PseudoPotentialFamily.create_from_folder` class method for file that fails to parse.
 
@@ -137,14 +137,14 @@ def test_create_from_folder_parse_fail(tmp_path):
         PseudoPotentialFamily.create_from_folder(tmp_path, 'label')
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder_empty(tmp_path):
     """Test the `PseudoPotentialFamily.create_from_folder` class method for empty folder."""
     with pytest.raises(ValueError, match=r'no pseudo potentials were parsed from.*'):
         PseudoPotentialFamily.create_from_folder(tmp_path, 'label')
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder_duplicate_element(tmp_path, filepath_pseudos):
     """Test the `PseudoPotentialFamily.create_from_folder` class method for folder containing duplicate element."""
     dirpath = tmp_path / 'pseudos'
@@ -156,7 +156,7 @@ def test_create_from_folder_duplicate_element(tmp_path, filepath_pseudos):
         PseudoPotentialFamily.create_from_folder(dirpath, 'label')
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder_duplicate(filepath_pseudos):
     """Test that `PseudoPotentialFamily.create_from_folder` raises for duplicate label."""
     label = 'label'
@@ -213,7 +213,7 @@ def test_parse_pseudos_from_directory_incorrect_pseudo_type(tmp_path):
         SomeFamily.parse_pseudos_from_directory(tmp_path, pseudo_type=PsmlData)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_add_nodes(get_pseudo_family, get_pseudo_potential_data):
     """Test that `PseudoPotentialFamily.add_nodes` method."""
     family = get_pseudo_family(elements=('Rn',))
@@ -249,7 +249,7 @@ def nodes_unstored(get_pseudo_potential_data, request):
     return [get_pseudo_potential_data(), get_pseudo_potential_data('Ne')]
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('nodes_unstored', ['single', 'tuple', 'list'], indirect=True)
 def test_add_nodes_unstored(get_pseudo_family, nodes_unstored):
     """Test that `PseudoPotentialFamily.add_nodes` fails if one or more nodes are unstored."""
@@ -276,7 +276,7 @@ def nodes_incorrect_type(get_pseudo_potential_data, request):
     return [get_pseudo_potential_data().store(), Data().store()]
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('nodes_incorrect_type', ['single', 'tuple', 'list'], indirect=True)
 def test_add_nodes_incorrect_type(get_pseudo_family, nodes_incorrect_type):
     """Test that `PseudoPotentialFamily.add_nodes` fails if one or more nodes has the incorrect type.
@@ -293,7 +293,7 @@ def test_add_nodes_incorrect_type(get_pseudo_family, nodes_incorrect_type):
     assert family.count() == count
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_add_nodes_duplicate_element(get_pseudo_family, get_pseudo_potential_data):
     """Test that `PseudoPotentialFamily.add_nodes` fails if a pseudo is added whose element already exists."""
     family = get_pseudo_family(elements=('Ar',))
@@ -303,7 +303,7 @@ def test_add_nodes_duplicate_element(get_pseudo_family, get_pseudo_potential_dat
         family.add_nodes(pseudo)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_remove_nodes(get_pseudo_family):
     """Test the ``PseudoPotentialFamily.remove_nodes`` method."""
     elements = ('Ar', 'He', 'Kr')
@@ -320,7 +320,7 @@ def test_remove_nodes(get_pseudo_family):
     assert family.pseudos == {}
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_remove_nodes_not_existing(get_pseudo_family, get_pseudo_potential_data):
     """Test the ``PseudoPotentialFamily.remove_nodes`` method works even when passing a non-existing pseudo.
 
@@ -337,7 +337,7 @@ def test_remove_nodes_not_existing(get_pseudo_family, get_pseudo_potential_data)
     assert tuple(family.pseudos.keys()) == ('Ar',)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_clear(get_pseudo_family):
     """Test the ``PseudoPotentialFamily.clear`` method."""
     family = get_pseudo_family(elements=('Ar', 'He', 'Kr'))
@@ -348,7 +348,7 @@ def test_clear(get_pseudo_family):
     assert family.count() == 0
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_pseudos(get_pseudo_potential_data):
     """Test the `PseudoPotentialFamily.pseudos` property."""
     pseudos = {
@@ -360,7 +360,7 @@ def test_pseudos(get_pseudo_potential_data):
     assert family.pseudos == pseudos
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_pseudos_mutate(get_pseudo_family, get_pseudo_potential_data):
     """Test that `PseudoPotentialFamily.pseudos` property does not act as a setter."""
     family = get_pseudo_family()
@@ -369,7 +369,7 @@ def test_pseudos_mutate(get_pseudo_family, get_pseudo_potential_data):
         family.pseudos = {'He': get_pseudo_potential_data('He')}
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_elements(get_pseudo_family):
     """Test the `PseudoPotentialFamily.elements` property."""
     elements = ['Ar', 'He']
@@ -380,7 +380,7 @@ def test_elements(get_pseudo_family):
     assert family.elements == []
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_pseudo(get_pseudo_family):
     """Test the `PseudoPotentialFamily.get_pseudo` method."""
     element = 'Ar'
@@ -392,7 +392,7 @@ def test_get_pseudo(get_pseudo_family):
         family.get_pseudo('He')
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_pseudos_raise(get_pseudo_family, generate_structure):
     """Test the `PseudoPotentialFamily.get_pseudos` method when it is supposed to raise."""
     elements = ('Ar', 'He', 'Ne')
@@ -418,7 +418,7 @@ def test_get_pseudos_raise(get_pseudo_family, generate_structure):
         family.get_pseudos(structure=structure)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_pseudos_list(get_pseudo_family):
     """Test the `PseudoPotentialFamily.get_pseudos` method when passing a list of elements."""
     elements = ('Ar', 'He', 'Ne')
@@ -430,7 +430,7 @@ def test_get_pseudos_list(get_pseudo_family):
         assert isinstance(pseudos[element], PseudoPotentialData)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_pseudos_structure(get_pseudo_family, generate_structure):
     """Test the `PseudoPotentialFamily.get_pseudos` method when passing a ``StructureData`` instance."""
     elements = ('Ar', 'He', 'Ne')
@@ -443,7 +443,7 @@ def test_get_pseudos_structure(get_pseudo_family, generate_structure):
         assert isinstance(pseudos[element], PseudoPotentialData)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_pseudos_structure_kinds(get_pseudo_family, generate_structure):
     """Test the `PseudoPotentialFamily.get_pseudos` for ``StructureData`` with kind names including digits."""
     elements = ('Ar1', 'Ar2')

--- a/tests/groups/family/test_pseudo_dojo.py
+++ b/tests/groups/family/test_pseudo_dojo.py
@@ -4,7 +4,7 @@ from aiida_pseudo.data.pseudo import JthXmlData, PsmlData, Psp8Data, UpfData
 from aiida_pseudo.groups.family import PseudoDojoConfiguration, PseudoDojoFamily
 
 
-def test_type_string(clear_db):
+def test_type_string(aiida_profile_clean):
     """Verify the `_type_string` class attribute is correctly set to the corresponding entry point name."""
     assert PseudoDojoFamily._type_string == 'pseudo.family.pseudo_dojo'
 
@@ -56,7 +56,7 @@ def test_constructor():
     assert isinstance(family, PseudoDojoFamily)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder(filepath_pseudos):
     """Test the `PseudoDojoFamily.create_from_folder` class method."""
     family = PseudoDojoFamily.create_from_folder(
@@ -65,7 +65,7 @@ def test_create_from_folder(filepath_pseudos):
     assert isinstance(family, PseudoDojoFamily)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder_duplicate(filepath_pseudos):
     """Test that `PseudoDojoFamily.create_from_folder` raises for duplicate label."""
     label = 'PseudoDojo/0.4/PBE/SR/standard/psp8'

--- a/tests/groups/family/test_sssp.py
+++ b/tests/groups/family/test_sssp.py
@@ -4,7 +4,7 @@ from aiida_pseudo.data.pseudo.upf import UpfData
 from aiida_pseudo.groups.family import SsspConfiguration, SsspFamily
 
 
-def test_type_string(clear_db):
+def test_type_string(aiida_profile_clean):
     """Verify the `_type_string` class attribute is correctly set to the corresponding entry point name."""
     assert SsspFamily._type_string == 'pseudo.family.sssp'
 
@@ -56,14 +56,14 @@ def test_constructor():
     assert isinstance(family, SsspFamily)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder(filepath_pseudos):
     """Test the `SsspFamily.create_from_folder` class method."""
     family = SsspFamily.create_from_folder(filepath_pseudos('upf'), 'SSSP/1.1/PBE/efficiency', pseudo_type=UpfData)
     assert isinstance(family, SsspFamily)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_create_from_folder_duplicate(filepath_pseudos):
     """Test that `SsspFamily.create_from_folder` raises for duplicate label."""
     label = 'SSSP/1.1/PBE/efficiency'

--- a/tests/groups/mixins/test_cutoffs.py
+++ b/tests/groups/mixins/test_cutoffs.py
@@ -5,7 +5,7 @@ import pytest
 from aiida_pseudo.groups.family import CutoffsPseudoPotentialFamily
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_cutoffs_dict(get_pseudo_family, generate_cutoffs_dict):
     """Test the ``CutoffsPseudoPotentialFamily._get_cutoffs_dict`` method."""
     family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
@@ -16,7 +16,7 @@ def test_get_cutoffs_dict(get_pseudo_family, generate_cutoffs_dict):
     assert family._get_cutoffs_dict() == generate_cutoffs_dict(family)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_cutoffs_unit_dict(get_pseudo_family, generate_cutoffs_dict):
     """Test the ``CutoffsPseudoPotentialFamily._get_cutoffs_unit_dict`` method."""
     family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
@@ -30,7 +30,7 @@ def test_get_cutoffs_unit_dict(get_pseudo_family, generate_cutoffs_dict):
     assert family._get_cutoffs_unit_dict() == default_units_dict
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_validate_cutoffs_unit():
     """Test the ``CutoffsPseudoPotentialFamily.validate_cutoffs_unit`` method."""
     with pytest.raises(TypeError):
@@ -43,7 +43,7 @@ def test_validate_cutoffs_unit():
         CutoffsPseudoPotentialFamily.validate_cutoffs_unit('watt')
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_validate_stringency(get_pseudo_family, generate_cutoffs):
     """Test the ``CutoffsPseudoPotentialFamily.validate_stringency`` method."""
     family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
@@ -61,7 +61,7 @@ def test_validate_stringency(get_pseudo_family, generate_cutoffs):
     family.validate_stringency(stringency)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_default_stringency(get_pseudo_family, generate_cutoffs):
     """Test the ``CutoffsPseudoPotentialFamily.get_default_stringency`` method."""
     family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
@@ -76,7 +76,7 @@ def test_get_default_stringency(get_pseudo_family, generate_cutoffs):
     assert family.get_default_stringency() == stringency
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_default_stringency(get_pseudo_family, generate_cutoffs_dict):
     """Test the ``CutoffsPseudoPotentialFamily.set_default_stringency`` method."""
     family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
@@ -98,7 +98,7 @@ def test_set_default_stringency(get_pseudo_family, generate_cutoffs_dict):
     assert family.get_default_stringency() == 'normal'
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_cutoff_stringencies(get_pseudo_family, generate_cutoffs_dict):
     """Test the ``CutoffsPseudoPotentialFamily.get_cutoff_stringencies`` method."""
     family = get_pseudo_family(cls=CutoffsPseudoPotentialFamily)
@@ -111,7 +111,7 @@ def test_get_cutoff_stringencies(get_pseudo_family, generate_cutoffs_dict):
     assert sorted(family.get_cutoff_stringencies()) == sorted(stringencies)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_cutoffs(get_pseudo_family, generate_cutoffs):
     """Test the ``CutoffsPseudoPotentialFamily.set_cutoffs`` method."""
     elements = ['Ar', 'He']
@@ -149,7 +149,7 @@ def test_set_cutoffs(get_pseudo_family, generate_cutoffs):
         family.set_cutoffs(cutoffs_invalid, stringency)
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_cutoffs_unit_default(get_pseudo_family, generate_cutoffs):
     """Test the ``CutoffsPseudoPotentialFamily.set_cutoffs`` sets a default unit if not specified."""
     elements = ['Ar']
@@ -161,7 +161,7 @@ def test_set_cutoffs_unit_default(get_pseudo_family, generate_cutoffs):
     assert family.get_cutoffs_unit() == CutoffsPseudoPotentialFamily.DEFAULT_UNIT
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_cutoffs_multiple_units(get_pseudo_family, generate_cutoffs):
     """Test ``CutoffsPseudoPotentialFamily.set_cutoffs`` correctly sets separate units for different stringencies."""
     elements = ['Ar']
@@ -185,7 +185,7 @@ def test_set_cutoffs_multiple_units(get_pseudo_family, generate_cutoffs):
     assert family._get_cutoffs_unit_dict() == {'default': 'hartree', 'rydberg': 'Ry'}
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_set_cutoffs_auto_default(get_pseudo_family, generate_cutoffs):
     """Test that the ``CutoffsPseudoPotentialFamily.set_cutoffs`` method specifies the correct default stringency.
 
@@ -201,7 +201,7 @@ def test_set_cutoffs_auto_default(get_pseudo_family, generate_cutoffs):
     assert family.get_default_stringency() == 'default'
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_cutoffs(get_pseudo_family, generate_cutoffs):
     """Test the ``CutoffsPseudoPotentialFamily.get_cutoffs`` method."""
     elements = ['Ar', 'He']
@@ -225,7 +225,7 @@ def test_get_cutoffs(get_pseudo_family, generate_cutoffs):
     assert family.get_cutoffs('low') == low_cutoffs
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_recommended_cutoffs(get_pseudo_family, generate_structure, generate_cutoffs):
     """Test the ``CutoffsPseudoPotentialFamily.get_recommended_cutoffs`` method."""
     elements = ['Ar', 'He']
@@ -264,7 +264,7 @@ def test_get_recommended_cutoffs(get_pseudo_family, generate_structure, generate
     assert family.get_recommended_cutoffs(structure=structure) == (expected['cutoff_wfc'], expected['cutoff_rho'])
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_recommended_cutoffs_unit(get_pseudo_family, generate_cutoffs):
     """Test the ``CutoffsPseudoPotentialFamily.get_recommended_cutoffs`` method with the ``unit`` argument."""
     elements = ['Ar', 'He']
@@ -283,7 +283,7 @@ def test_get_recommended_cutoffs_unit(get_pseudo_family, generate_cutoffs):
     assert family.get_recommended_cutoffs(elements='Ar', unit='Ry') == expected
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_cutoffs_unit(get_pseudo_family, generate_cutoffs):
     """Test the ``CutoffsPseudoPotentialFamily.get_cutoffs_unit`` method."""
     elements = ['Ar', 'He']
@@ -303,7 +303,7 @@ def test_get_cutoffs_unit(get_pseudo_family, generate_cutoffs):
     assert family.get_cutoffs_unit() == 'Eh'
 
 
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('aiida_profile_clean')
 def test_delete_cutoffs(get_pseudo_family, generate_cutoffs_dict):
     """Test the ``CutoffsPseudoPotentialFamily.delete_cutoffs`` method."""
     elements = ['Ar', 'He']


### PR DESCRIPTION
Most notably, the `aiida_profile` and related fixtures now by default use a profile using the `core.sqlite_dos` storage plugin and define no broker. This means the PostgreSQL and RabbitMQ services are no longer required to run the tests.