### PR TITLE
Fix broken import of `aiida.manage.configuration.Config`

### DIFF
--- a/src/aiida_pseudo/data/pseudo/pseudo.py
+++ b/src/aiida_pseudo/data/pseudo/pseudo.py
@@ -17,7 +17,7 @@ __all__ = ('PseudoPotentialData',)
 class PseudoPotentialDataCaching(NodeCaching):
     """Class to define caching behavior of ``PseudoPotentialData`` nodes."""
 
-    def _get_objects_to_hash(self) -> list:
+    def get_objects_to_hash(self) -> list:
         """Return a list of objects which should be included in the node hash."""
         return [self._node.element, self._node.md5]
 

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -4,7 +4,7 @@ import json
 import pathlib
 
 import pytest
-from aiida.manage.configuration import Config
+from aiida.manage.configuration.config import Config
 from aiida.orm import QueryBuilder
 from aiida_pseudo.cli import cmd_install_family, cmd_install_pseudo_dojo, cmd_install_sssp, install
 from aiida_pseudo.data.pseudo.upf import UpfData

--- a/tests/data/pseudo/test_pseudo.py
+++ b/tests/data/pseudo/test_pseudo.py
@@ -233,4 +233,4 @@ def test_hash(stream, filename, element, are_equal):
     right.element = element
     right.store()
 
-    assert (left.base.caching.get_hash() == right.base.caching.get_hash()) is are_equal
+    assert (left.base.caching.compute_hash() == right.base.caching.compute_hash()) is are_equal


### PR DESCRIPTION
A recent release of `aiida-core` removed the import of `Config` directly from the module `aiida.manage.configuration` causing the tests to fail. It should now be imported from `aiida.manage.configuration.config.Config`.