### PR TITLE
Proposed fix for HTTPSConnection Issue with PseudoDojo

### DIFF
--- a/src/aiida_pseudo/cli/install.py
+++ b/src/aiida_pseudo/cli/install.py
@@ -313,14 +313,14 @@ def download_pseudo_dojo(
     url_metadata = PseudoDojoFamily.get_url_metadata(label)
 
     with attempt('downloading selected pseudopotentials archive... ', include_traceback=traceback):
-        response = requests.get(url_archive, timeout=30)
+        response = requests.get(url_archive, timeout=30, verify=False)
         response.raise_for_status()
         with open(filepath_archive, 'wb') as handle:
             handle.write(response.content)
             handle.flush()
 
     with attempt('downloading selected pseudopotentials metadata archive... ', include_traceback=traceback):
-        response = requests.get(url_metadata, timeout=30)
+        response = requests.get(url_metadata, timeout=30, verify=False)
         response.raise_for_status()
         with open(filepath_metadata, 'wb') as handle:
             handle.write(response.content)


### PR DESCRIPTION
Hey  All, 

I tried to download a version of pseudo dojo pseudopotentials however I couldn't due to : 

```
Report: downloading selected pseudopotentials archive...  [FAILED]
Critical: HTTPSConnectionPool(host='www.pseudo-dojo.org', port=443): Max retries exceeded with url: /pseudos/nc-fr-04_pbesol_standard_psp8.tgz (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)')))
```

As a quick fix we can bypass the certificate check when we download the specific pseudopotentials. Happy to hear any feedback. Thanks :D 