### PR TITLE
Move `aiida-core~=2.6` dependency to dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   'Programming Language :: Python :: 3.12'
 ]
 dependencies = [
-  'aiida-core~=2.6',
+  'aiida-core~=2.1',
   'click~=8.0',
   'pint~=0.23.0',
   'requests~=2.20'
@@ -46,6 +46,7 @@ requires-python = '>=3.9'
 
 [project.optional-dependencies]
 dev = [
+  'aiida-core~=2.6',
   'pre-commit~=2.2',
   'pytest>=6.0'
 ]


### PR DESCRIPTION
This PR reverts the `aiida-core` dependency back to `~=2.1` and moves the `~=2.6` pin to `dev` dependencies. See resolved issue for detail.

Resolves #180