### PR TITLE
Devops: Pin requirement `sphinx-autoapi~=3.3.3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ docs = [
   'sphinx~=6.0',
   'sphinx-copybutton~=0.5.0',
   'sphinx-book-theme~=1.0',
-  'sphinx-autoapi~=3.0',
+  'sphinx-autoapi~=3.3.3,',
   'sphinx-click~=4.0'
 ]
 


### PR DESCRIPTION
The release `sphinx-autoapi==3.4.0` causes the docs build to fail.

See https://github.com/readthedocs/sphinx-autoapi/issues/504