### PR TITLE
👌 Add path to sphinx `conf.py` to RTD configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,4 @@ python:
 sphinx:
   builder: html
   fail_on_warning: true
+  configuration: docs/source/conf.py


### PR DESCRIPTION
Projects without an explicit configuration in `.readthedocs.yaml` are deprecated, see:

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
