### PR TITLE
update pint dependency to python 3.13

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
   'aiida-core~=2.6',
   'click~=8.0,<8.2',
-  'pint~=0.23.0',
+  'pint>=0.23.0,<0.25.0',
   'requests~=2.20'
 ]
 dynamic = ['description', 'version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ classifiers = [
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
-  'Programming Language :: Python :: 3.12'
+  'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13'
 ]
 dependencies = [
   'aiida-core~=2.6',


### PR DESCRIPTION
Hello,

a simple upgrade of a dependency does not crash aiida when importing it in python 3.13

https://github.com/hgrecco/pint/issues/2065