### PR TITLE
Dependencies: Add upper pin `click<8.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
   'aiida-core~=2.6',
-  'click~=8.0',
+  'click~=8.0,<8.2',
   'pint~=0.23.0',
   'requests~=2.20'
 ]


### PR DESCRIPTION
The recent release v8.2 breaks the CLI from `aiida-core`. Until that is fixed, an upper limit is opposed as a temporary fix.