### PR TITLE
♻️ Fix tests

### DIFF
--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -29,7 +29,7 @@ def empty_config() -> Config:
     from aiida.manage.configuration import settings
 
     current_config = configuration.CONFIG
-    current_config_path = current_config.dirpath
+    current_config_path = pathlib.Path(current_config.dirpath)
     current_profile = configuration.get_profile()
     current_path_variable = os.environ.get(settings.DEFAULT_AIIDA_PATH_VARIABLE, None)
 
@@ -39,8 +39,7 @@ def empty_config() -> Config:
     with tempfile.TemporaryDirectory() as dirpath:
         dirpath_config = pathlib.Path(dirpath) / 'config'
         os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = str(dirpath_config)
-        settings.AIIDA_CONFIG_FOLDER = str(dirpath_config)
-        settings.set_configuration_directory()
+        settings.AiiDAConfigDir.set(dirpath_config)
         configuration.CONFIG = configuration.load_config(create=True)
 
         try:
@@ -51,8 +50,7 @@ def empty_config() -> Config:
             else:
                 os.environ[settings.DEFAULT_AIIDA_PATH_VARIABLE] = current_path_variable
 
-            settings.AIIDA_CONFIG_FOLDER = current_config_path
-            settings.set_configuration_directory()
+            settings.AiiDAConfigDir.set(current_config_path)
             configuration.CONFIG = current_config
 
             if current_profile:

--- a/tests/data/pseudo/test_pseudo.py
+++ b/tests/data/pseudo/test_pseudo.py
@@ -32,12 +32,6 @@ def test_constructor_source_types(source):
     assert not pseudo.is_stored
 
 
-def test_constructor_invalid():
-    """Test the constructor for invalid arguments."""
-    with pytest.raises(TypeError, match='missing 1 required positional argument'):
-        PseudoPotentialData()
-
-
 @pytest.mark.usefixtures('chdir_tmp_path')
 @pytest.mark.parametrize('source_type', ('stream', 'str_absolute', 'str_relative', 'pathlib.Path'))
 @pytest.mark.parametrize('implicit', (True, False))


### PR DESCRIPTION
The `empty_config` context manager is used for some of the testing infrastructure of the installation commands. It relied on some methods for adapting the AiiDA configuration folder, whose API has been changed in

https://github.com/aiidateam/aiida-core/commit/9baf3ca96caa5577ec8ed6cef69512f430bb5675

Here we adapt the `empty_config` context manager to rely on the new API using the `AiiDAConfigDir`.