### PR TITLE
Optionally allow `None` for missing pseudos in a family

### DIFF
--- a/src/aiida_pseudo/groups/family/pseudo.py
+++ b/src/aiida_pseudo/groups/family/pseudo.py
@@ -347,11 +347,7 @@ class PseudoPotentialFamily(Group):
 
         if structure is not None:
             return {
-                kind.name: self.get_pseudo(kind.symbol, none_if_missing=none_if_missing)
-                for kind in structure.kinds
+                kind.name: self.get_pseudo(kind.symbol, none_if_missing=none_if_missing) for kind in structure.kinds
             }
 
-        return {
-            element: self.get_pseudo(element, none_if_missing=none_if_missing)
-            for element in elements
-        }
+        return {element: self.get_pseudo(element, none_if_missing=none_if_missing) for element in elements}

--- a/tests/groups/family/test_pseudo.py
+++ b/tests/groups/family/test_pseudo.py
@@ -431,7 +431,8 @@ def test_get_pseudos_raise(get_pseudo_family, generate_structure):
     with pytest.raises(ValueError, match=r'family `.*` does not contain pseudo for element `.*`'):
         family.get_pseudos(structure=structure)
 
-    assert family.get_pseudos(structure=structure, none_if_missing=True)['He'] is None
+    assert family.get_pseudos(structure=structure, none_if_missing=True)['Ne'] is None
+
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 def test_get_pseudos_list(get_pseudo_family):


### PR DESCRIPTION
At the moment, using `PseudoPotentialFamily.get_pseudos()` will fail for all if at least one element does not have a corresponding pseudopotential in the family. This PR aims to allow a path for partial results, returning `None` for those missing elements, if user opt in by way of an optional `none_if_missing` parameter (`False` by default for backwards compatibility).

This allows the QE app, for example, to do this:

<img width="956" height="814" alt="image" src="https://github.com/user-attachments/assets/2b230c88-c906-4558-94e0-11a970cdd977" />