### PR TITLE
👌 `PseudoPotentialData`: Improve string representation

### DIFF
--- a/src/aiida_pseudo/data/pseudo/pseudo.py
+++ b/src/aiida_pseudo/data/pseudo/pseudo.py
@@ -30,6 +30,13 @@ class PseudoPotentialData(plugins.DataFactory('core.singlefile')):
 
     _CLS_NODE_CACHING = PseudoPotentialDataCaching
 
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__}[{self.element}] (pk: {self.pk})>'
+
+    def get_description(self) -> str:
+        """Returns a string that describes the pseudopotential"""
+        return repr(self)
+
     @classmethod
     def get_or_create(
         cls, source: typing.Union[str, pathlib.Path, typing.BinaryIO], filename: typing.Optional[str] = None


### PR DESCRIPTION
The `PseudoPotentialData` is currently missing a `get_description` method, which means this returns the default empty string derived from the `Node` class. The default `__repr__` method also does not show one of the most important attributes of the `PseudoPotentialData` class: the element it represents.

Here we add the `__repr__` and `get_description` methods to the `PseudoPotentialData` class. Although these could (and perhaps should) serve a different purpose, we don't want users to be confused when they see a difference between:

* the pseudos dictionary returned by `builder.pseudos`, which uses `__repr__`.
* The `__repr_pretty__` method of the `ProcessBuilder`, which uses `get_description` for `Node` objects.

Hence, we make them return the same output by having the `get_description` method call `repr`. For the contents, we choose to add:

* The class name, so they can see the type of pseudopotential.
* The element of the pseudopotential.
* The PK of the pseudpotential node.

We skip the UUID to reduce the noise. In most local usage the PK is much more common, and the user can still easily get the UUID using `node.uuid`.